### PR TITLE
Phase 3: codegen core (pack, fragment, ANSI to HTML)

### DIFF
--- a/src/codegen/fragment.test.ts
+++ b/src/codegen/fragment.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { collectHelpers } from './fragment';
+import type { CodeFragment } from '../schema/types';
+
+const f = (helpers: string[]): CodeFragment => ({ helpers, expr: '""' });
+
+describe('collectHelpers', () => {
+  it('returns unique helper ids preserving first-seen order', () => {
+    expect(collectHelpers([f(['a','b']), f(['b','c']), f(['a','d'])])).toEqual(['a','b','c','d']);
+  });
+  it('handles empty input', () => {
+    expect(collectHelpers([])).toEqual([]);
+  });
+});

--- a/src/codegen/fragment.ts
+++ b/src/codegen/fragment.ts
@@ -1,0 +1,12 @@
+import type { CodeFragment } from '../schema/types';
+
+export function collectHelpers(fragments: CodeFragment[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const f of fragments) {
+    for (const h of f.helpers) {
+      if (!seen.has(h)) { seen.add(h); out.push(h); }
+    }
+  }
+  return out;
+}

--- a/src/codegen/pack.test.ts
+++ b/src/codegen/pack.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { packLines } from './pack';
+import type { ResolvedOptions } from '../schema/types';
+
+const opts = (over: Partial<ResolvedOptions['global']> = {}): ResolvedOptions => ({
+  global: {
+    lineLength: 100, separator: ' | ', useEmojis: true, hardLimit: false,
+    tolerancePct: 10, padding: 0, refreshInterval: null,
+    hideVimModeIndicator: false, cacheGit: true, cacheStalenessSec: 5,
+    ...over,
+  },
+  sub: {},
+});
+
+describe('packLines', () => {
+  it('keeps everything on one line when under limit', () => {
+    expect(packLines([10, 10, 10], opts())).toEqual([[0, 1, 2]]);
+  });
+  it('breaks when over limit', () => {
+    expect(packLines([10, 10, 10], opts({ lineLength: 20 }))).toEqual([[0, 1], [2]]);
+  });
+  it('respects 10% tolerance under soft limit', () => {
+    expect(packLines([50, 50], opts())).toEqual([[0, 1]]);
+  });
+  it('hard limit ignores tolerance', () => {
+    expect(packLines([50, 50], opts({ hardLimit: true }))).toEqual([[0], [1]]);
+  });
+});

--- a/src/codegen/pack.ts
+++ b/src/codegen/pack.ts
@@ -1,0 +1,21 @@
+import type { ResolvedOptions } from '../schema/types';
+
+export function packLines(widths: number[], opts: ResolvedOptions): number[][] {
+  const { lineLength, separator, hardLimit, tolerancePct } = opts.global;
+  const sepW = separator.length;
+  const limit = hardLimit ? lineLength : lineLength * (1 + tolerancePct / 100);
+
+  const lines: number[][] = [[]];
+  let running = 0;
+  widths.forEach((wi, i) => {
+    const cur = lines[lines.length - 1];
+    const addCost = cur.length > 0 ? sepW + wi : wi;
+    const checkCost = hardLimit ? addCost : wi;
+    if (cur.length > 0 && running + checkCost > limit) {
+      lines.push([i]); running = wi;
+    } else {
+      cur.push(i); running += addCost;
+    }
+  });
+  return lines.filter((l) => l.length > 0);
+}

--- a/src/output/ansiToHtml.test.ts
+++ b/src/output/ansiToHtml.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { ansiToHtml } from './ansiToHtml';
+
+describe('ansiToHtml', () => {
+  it('returns plain text unchanged (escaped)', () => {
+    expect(ansiToHtml('hello')).toBe('hello');
+  });
+  it('wraps colored runs in spans', () => {
+    expect(ansiToHtml('\x1b[32mok\x1b[0m')).toContain('color:#5af78e');
+    expect(ansiToHtml('\x1b[32mok\x1b[0m')).toContain('ok</span>');
+  });
+  it('renders OSC 8 hyperlinks', () => {
+    const html = ansiToHtml('\x1b]8;;https://example.com\x07click\x1b]8;;\x07');
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain('>click<');
+  });
+  it('escapes HTML special chars', () => {
+    expect(ansiToHtml('<b>')).toBe('&lt;b&gt;');
+  });
+});

--- a/src/output/ansiToHtml.ts
+++ b/src/output/ansiToHtml.ts
@@ -1,0 +1,51 @@
+const COLORS: Record<string, string> = {
+  '30': '#000000', '31': '#ff5c57', '32': '#5af78e', '33': '#f3f99d',
+  '34': '#57c7ff', '35': '#ff6ac1', '36': '#9aedfe', '37': '#f1f1f0',
+};
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]!,
+  );
+}
+
+interface LinkSlot { url: string; text: string; }
+
+export function ansiToHtml(input: string): string {
+  const slots: LinkSlot[] = [];
+  const linkRe = /\x1b\]8;;([^\x07]*)\x07([^\x1b]*)\x1b\]8;;\x07/g;
+  const withSlots = input.replace(linkRe, (_m, url, text) => {
+    slots.push({ url, text });
+    return `\x00SLOT${slots.length - 1}\x00`;
+  });
+
+  const csi = /\x1b\[([0-9;]*)m/g;
+  let result = '';
+  let cursor = 0;
+  let openSpan = false;
+  let m: RegExpExecArray | null;
+  while ((m = csi.exec(withSlots))) {
+    result += escapeHtml(withSlots.slice(cursor, m.index));
+    cursor = m.index + m[0].length;
+    const codes = m[1].split(';').filter(Boolean);
+    if (codes.length === 0 || codes.includes('0')) {
+      if (openSpan) { result += '</span>'; openSpan = false; }
+      continue;
+    }
+    const color = codes.map((c) => COLORS[c]).find(Boolean);
+    if (color) {
+      if (openSpan) result += '</span>';
+      result += `<span style="color:${color}">`;
+      openSpan = true;
+    }
+  }
+  result += escapeHtml(withSlots.slice(cursor));
+  if (openSpan) result += '</span>';
+
+  result = result.replace(/\x00SLOT(\d+)\x00/g, (_m, idxStr) => {
+    const slot = slots[Number(idxStr)];
+    return `<a href="${escapeHtml(slot.url)}" target="_blank" rel="noopener">${escapeHtml(slot.text)}</a>`;
+  });
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- `src/output/ansiToHtml.ts` — ANSI CSI color codes + OSC 8 hyperlinks → HTML spans/anchors for the live preview pane
- `src/codegen/pack.ts` — gen-time line packer: groups param indices into rows respecting `lineLength` + soft tolerance / hard limit
- `src/codegen/fragment.ts` — deduplicates helper ids across fragments, preserving first-seen order

20/20 tests passing, typecheck clean. These three utilities are the foundation Phase 4 emitters build on.