### PR TITLE
Phase 4: codegen emitters (JS, Python, Bash, PowerShell, settings)

### DIFF
--- a/src/codegen/__snapshots__/emitBash.test.ts.snap
+++ b/src/codegen/__snapshots__/emitBash.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`emitBash > basic selection snapshot 1`] = `
+"#!/bin/bash
+# Requires: jq
+input=$(cat)
+__strip_ansi() { echo "$1" | sed $'s/\\\\e\\\\[[0-9;]*m//g'; }
+__pack() {
+  local sep=$1 max=$2 hard=$3 tol=$4; shift 4
+  local lim result="" run=0
+  if [ "$hard" = "true" ]; then lim=$max
+  else lim=$(awk "BEGIN{printf \\"%d\\",$max*(1+$tol/100)}"); fi
+  for p in "$@"; do
+    [ -z "$p" ] && continue
+    local l; l=$(echo "$p"|__strip_ansi|wc -m)
+    local add=$l
+    [ -n "$result" ] && add=$(( add + \${#sep} ))
+    if [ -n "$result" ] && [ $(( run + add )) -gt $lim ]; then
+      result="$result\\n$p"; run=$l
+    else
+      result="\${result:+$result$sep}$p"; run=$(( run + add ))
+    fi
+  done
+  printf "%b\\n" "$result"
+}
+__truncate_path() {
+  local p=$1 max=\${2:-40} base=\${3:-0}
+  [ -z "$p" ] && echo "" && return
+  [ "$base" = "1" ] || [ "$base" = "true" ] && p=$(basename "$p")
+  if [ \${#p} -le $max ]; then echo "$p"
+  else echo "…\${p: -(max-1)}"; fi
+}
+G=$'\\e[32m'; Y=$'\\e[33m'; R=$'\\e[31m'; C=$'\\e[36m'; X=$'\\e[0m'
+__bar() {
+  local pct=$1 w=\${2:-10} wa=\${3:-75} ra=\${4:-90}
+  local f=$(( (pct * w + 50) / 100 )) e bar="" i
+  e=$(( w - f ))
+  for ((i=0;i<f;i++)); do bar+=$'\\u2593'; done
+  for ((i=0;i<e;i++)); do bar+=$'\\u2591'; done
+  local c
+  if [ "$pct" -ge "$ra" ]; then c=$R
+  elif [ "$pct" -ge "$wa" ]; then c=$Y
+  else c=$G; fi
+  printf "%s%s%s" "$c" "$bar" "$X"
+}
+MODEL_DISPLAY=$(echo "$input"|jq -r '.model.display_name//"?"')
+CWD_RAW=$(echo "$input"|jq -r '.workspace.current_dir//(.cwd//"")')
+CTX_BAR_PCT=$(echo "$input"|jq -r '.context_window.used_percentage//0|floor')
+__pack " | " 100 false 10 "\${MODEL_DISPLAY}" "$(__truncate_path "\${CWD_RAW}" 40 1)" "$(__bar "\${CTX_BAR_PCT}" 10 75 90)"
+"
+`;

--- a/src/codegen/__snapshots__/emitJs.test.ts.snap
+++ b/src/codegen/__snapshots__/emitJs.test.ts.snap
@@ -1,0 +1,77 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`emitJs > emits ctx_bar with bar helper 1`] = `
+"#!/usr/bin/env node
+let input = '';
+process.stdin.on('data', (c) => (input += c));
+process.stdin.on('end', () => {
+  try {
+    const d = JSON.parse(input);
+    const __stripAnsi=(s)=>String(s).replace(/\\x1b\\[[0-9;]*m/g,'').replace(/\\x1b\\]8;;[^\\x07]*\\x07/g,'');
+    const __pack=(parts,sep=' | ',max=100,hard=false,tol=10)=>{const ps=parts.filter(x=>x!=null&&x!=='');if(!ps.length)return'';const lim=hard?max:max*(1+tol/100),lines=[[]];let run=0;for(const p of ps){const l=__stripAnsi(String(p)).length,add=l+(lines[lines.length-1].length?sep.length:0);if(lines[lines.length-1].length&&run+add>lim){lines.push([p]);run=l}else{lines[lines.length-1].push(p);run+=add}}return lines.map(l=>l.join(sep)).join('\\n')};
+    const G='\\x1b[32m',Y='\\x1b[33m',R='\\x1b[31m',C='\\x1b[36m',X='\\x1b[0m';
+    const __bar=(pct,w=10,wa=75,ra=90)=>{const f=Math.round((pct/100)*w),b='\\u2593'.repeat(Math.max(0,f))+'\\u2591'.repeat(Math.max(0,w-f)),c=pct>=ra?R:pct>=wa?Y:G;return c+b+X};
+    console.log(__pack([d.model?.display_name??'?', __bar(d.context_window?.used_percentage??0,10,75,90)], " | ", 100, false, 10));
+  } catch (_e) {
+    console.log('[?]');
+  }
+});
+"
+`;
+
+exports[`emitJs > emits git extraction block with cache when git params selected 1`] = `
+"#!/usr/bin/env node
+let input = '';
+process.stdin.on('data', (c) => (input += c));
+process.stdin.on('end', () => {
+  try {
+    const d = JSON.parse(input);
+    const __stripAnsi=(s)=>String(s).replace(/\\x1b\\[[0-9;]*m/g,'').replace(/\\x1b\\]8;;[^\\x07]*\\x07/g,'');
+    const __pack=(parts,sep=' | ',max=100,hard=false,tol=10)=>{const ps=parts.filter(x=>x!=null&&x!=='');if(!ps.length)return'';const lim=hard?max:max*(1+tol/100),lines=[[]];let run=0;for(const p of ps){const l=__stripAnsi(String(p)).length,add=l+(lines[lines.length-1].length?sep.length:0);if(lines[lines.length-1].length&&run+add>lim){lines.push([p]);run=l}else{lines[lines.length-1].push(p);run+=add}}return lines.map(l=>l.join(sep)).join('\\n')};
+    const __runGit=()=>{try{const ex=(cmd)=>require('child_process').execSync(cmd,{stdio:['ignore','pipe','ignore'],encoding:'utf8'}).trim();const branch=ex('git rev-parse --abbrev-ref HEAD');const staged=parseInt(ex('git diff --cached --numstat 2>/dev/null|wc -l')||'0',10);const modified=parseInt(ex('git diff --numstat 2>/dev/null|wc -l')||'0',10);let remote='';try{remote=ex('git remote get-url origin 2>/dev/null')}catch(_){}return[branch,staged,modified,remote]}catch(_){return['?',0,0,'']}};
+    const __cacheGit=(sid,ttl,run)=>{const os=require('os'),fs=require('fs'),f=os.tmpdir()+'/statusline-git-cache-'+sid;try{const c=JSON.parse(fs.readFileSync(f,'utf8'));if(Date.now()-c.ts<ttl*1e3)return c.d}catch(e){}const d=run();try{fs.writeFileSync(f,JSON.stringify({ts:Date.now(),d}))}catch(e){}return d};
+    const G='\\x1b[32m',Y='\\x1b[33m',R='\\x1b[31m',C='\\x1b[36m',X='\\x1b[0m';
+    const __GIT = __cacheGit(d.session_id ?? 'default', 5, __runGit);
+    console.log(__pack([d.model?.display_name??'?', __GIT[0], (__GIT[2]>0?(__GIT[2]>=1?R:__GIT[2]>=1?Y:G)+'M:'+__GIT[2]+X:'')], " | ", 100, false, 10));
+  } catch (_e) {
+    console.log('[?]');
+  }
+});
+"
+`;
+
+exports[`emitJs > emits resetTime helper for rate_5h_resets 1`] = `
+"#!/usr/bin/env node
+let input = '';
+process.stdin.on('data', (c) => (input += c));
+process.stdin.on('end', () => {
+  try {
+    const d = JSON.parse(input);
+    const __stripAnsi=(s)=>String(s).replace(/\\x1b\\[[0-9;]*m/g,'').replace(/\\x1b\\]8;;[^\\x07]*\\x07/g,'');
+    const __pack=(parts,sep=' | ',max=100,hard=false,tol=10)=>{const ps=parts.filter(x=>x!=null&&x!=='');if(!ps.length)return'';const lim=hard?max:max*(1+tol/100),lines=[[]];let run=0;for(const p of ps){const l=__stripAnsi(String(p)).length,add=l+(lines[lines.length-1].length?sep.length:0);if(lines[lines.length-1].length&&run+add>lim){lines.push([p]);run=l}else{lines[lines.length-1].push(p);run+=add}}return lines.map(l=>l.join(sep)).join('\\n')};
+    const __resetTime=(epoch,fmt='until')=>{if(!epoch)return'?';const dt=new Date(epoch*1e3),now=new Date(),diff=Math.max(0,dt-now),pad=n=>String(n).padStart(2,'0');if(fmt==='until'){const h=Math.floor(diff/36e5),m=Math.floor((diff%36e5)/6e4);return h>0?h+'h '+m+'m':m+'m'}if(fmt==='YYYY-MM-DD')return dt.getFullYear()+'-'+pad(dt.getMonth()+1)+'-'+pad(dt.getDate());if(fmt==='DD/MM/YY')return pad(dt.getDate())+'/'+pad(dt.getMonth()+1)+'/'+String(dt.getFullYear()).slice(2);if(fmt==='HH:mm')return pad(dt.getHours())+':'+pad(dt.getMinutes());return String(epoch)};
+    console.log(__pack([__resetTime(d.rate_limits?.five_hour?.resets_at,"until")], " | ", 100, false, 10));
+  } catch (_e) {
+    console.log('[?]');
+  }
+});
+"
+`;
+
+exports[`emitJs > produces a runnable script for a basic selection 1`] = `
+"#!/usr/bin/env node
+let input = '';
+process.stdin.on('data', (c) => (input += c));
+process.stdin.on('end', () => {
+  try {
+    const d = JSON.parse(input);
+    const __stripAnsi=(s)=>String(s).replace(/\\x1b\\[[0-9;]*m/g,'').replace(/\\x1b\\]8;;[^\\x07]*\\x07/g,'');
+    const __pack=(parts,sep=' | ',max=100,hard=false,tol=10)=>{const ps=parts.filter(x=>x!=null&&x!=='');if(!ps.length)return'';const lim=hard?max:max*(1+tol/100),lines=[[]];let run=0;for(const p of ps){const l=__stripAnsi(String(p)).length,add=l+(lines[lines.length-1].length?sep.length:0);if(lines[lines.length-1].length&&run+add>lim){lines.push([p]);run=l}else{lines[lines.length-1].push(p);run+=add}}return lines.map(l=>l.join(sep)).join('\\n')};
+    const __truncatePath=(p,max=40,base=false)=>{if(!p)return'';const s=base?(String(p).split('/').pop()||p):String(p);return s.length<=max?s:'\\u2026'+s.slice(-(max-1))};
+    console.log(__pack([d.model?.display_name??'?', __truncatePath(d.workspace?.current_dir??d.cwd??'',40,true)], " | ", 100, false, 10));
+  } catch (_e) {
+    console.log('[?]');
+  }
+});
+"
+`;

--- a/src/codegen/__snapshots__/emitPowershell.test.ts.snap
+++ b/src/codegen/__snapshots__/emitPowershell.test.ts.snap
@@ -1,0 +1,40 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`emitPowershell > basic selection snapshot 1`] = `
+"$ErrorActionPreference = 'Continue'
+try {
+    $d = $input | Out-String | ConvertFrom-Json
+
+function __Pack($parts,$sep=' | ',$max=100,$hard=$false,$tol=10){
+  $ps=$parts|Where-Object{$_ -ne $null -and $_ -ne ''}
+  if(-not $ps){return ''}
+  $lim=if($hard){$max}else{$max*(1+$tol/100)}
+  $lines=@(@()); $run=0
+  foreach($p in $ps){
+    $l=(Strip-Ansi([string]$p)).Length; $add=$l+$(if($lines[-1].Count -gt 0){$sep.Length}else{0})
+    if($lines[-1].Count -gt 0 -and ($run+$add) -gt $lim){$lines+=,@($p);$run=$l}
+    else{$lines[-1]+=$p;$run+=$add}
+  }
+  ($lines|ForEach-Object{$_-join $sep})-join "\`n"
+}
+function __TruncatePath($p,$max=40,$base=$false){
+  if(-not $p){return ''}
+  $s=if($base){Split-Path $p -Leaf}else{$p}
+  if($s.Length -le $max){$s}else{'…'+$s.Substring($s.Length-($max-1))}
+}
+$ESC=if($PSVersionTable.PSVersion.Major -ge 7){"$([char]27)"}else{[char]27}
+$G="$ESC[32m"; $Y="$ESC[33m"; $R="$ESC[31m"; $C="$ESC[36m"; $X="$ESC[0m"
+function __Bar($pct,$w=10,$wa=75,$ra=90){
+  $f=[Math]::Round(($pct/100)*$w); $e=$w-$f
+  $b=([string][char]0x2593)*[Math]::Max(0,$f)+([string][char]0x2591)*[Math]::Max(0,$e)
+  $c=if($pct -ge $ra){$R}elseif($pct -ge $wa){$Y}else{$G}
+  "$c$b$X"
+}
+$MODEL_DISPLAY=if($d.model.display_name){$d.model.display_name}else{"?"}
+$CWD_RAW=if($d.workspace.current_dir){$d.workspace.current_dir}elseif($d.cwd){$d.cwd}else{""}
+    Write-Host (__Pack @($MODEL_DISPLAY, (__TruncatePath $CWD_RAW 40 $true), (__Bar ([int]($d.context_window.used_percentage ?? 0)) 10 75 90)) " | " 100 $false 10)
+} catch {
+    Write-Host '[?]'
+}
+"
+`;

--- a/src/codegen/__snapshots__/emitPython.test.ts.snap
+++ b/src/codegen/__snapshots__/emitPython.test.ts.snap
@@ -1,0 +1,93 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`emitPython > basic selection snapshot 1`] = `
+"#!/usr/bin/env python3
+import json, sys
+def main():
+    try:
+        d = json.load(sys.stdin)
+import re as _re
+def __strip_ansi(s):
+    s=_re.sub(r'\\x1b\\[[0-9;]*m','',str(s))
+    return _re.sub(r'\\x1b\\]8;;[^\\x07]*\\x07','',s)
+def __pack(parts,sep=' | ',max_len=100,hard=False,tol=10):
+    ps=[str(p) for p in parts if p is not None and p!='']
+    if not ps: return ''
+    lim=max_len if hard else max_len*(1+tol/100)
+    lines=[[]]; run=0
+    for p in ps:
+        l=len(__strip_ansi(p)); add=l+(len(sep) if lines[-1] else 0)
+        if lines[-1] and run+add>lim: lines.append([p]); run=l
+        else: lines[-1].append(p); run+=add
+    return '\\n'.join(sep.join(line) for line in lines)
+def __truncate_path(p,max_len=40,base=False):
+    if not p: return ''
+    s=p.split('/')[-1] if base else p
+    return s if len(s)<=max_len else '\\u2026'+s[-(max_len-1):]
+G='\\x1b[32m'; Y='\\x1b[33m'; R='\\x1b[31m'; C='\\x1b[36m'; X='\\x1b[0m'
+def __bar(pct,w=10,wa=75,ra=90):
+    f=round((pct/100)*w); b='\\u2593'*max(0,f)+'\\u2591'*max(0,w-f)
+    c=R if pct>=ra else Y if pct>=wa else G
+    return c+b+X
+    print(__pack([(d.get('model') or {}).get('display_name','?'), __truncate_path((d.get('workspace') or {}).get('current_dir','') or d.get('cwd',''),40,True), __bar((d.get('context_window') or {}).get('used_percentage',0),10,75,90)], " | ", 100, False, 10))
+    except Exception:
+        print('[?]')
+
+if __name__ == '__main__':
+    main()
+"
+`;
+
+exports[`emitPython > git extraction block 1`] = `
+"#!/usr/bin/env python3
+import json, sys
+def main():
+    try:
+        d = json.load(sys.stdin)
+import re as _re
+def __strip_ansi(s):
+    s=_re.sub(r'\\x1b\\[[0-9;]*m','',str(s))
+    return _re.sub(r'\\x1b\\]8;;[^\\x07]*\\x07','',s)
+def __pack(parts,sep=' | ',max_len=100,hard=False,tol=10):
+    ps=[str(p) for p in parts if p is not None and p!='']
+    if not ps: return ''
+    lim=max_len if hard else max_len*(1+tol/100)
+    lines=[[]]; run=0
+    for p in ps:
+        l=len(__strip_ansi(p)); add=l+(len(sep) if lines[-1] else 0)
+        if lines[-1] and run+add>lim: lines.append([p]); run=l
+        else: lines[-1].append(p); run+=add
+    return '\\n'.join(sep.join(line) for line in lines)
+def __run_git():
+    import subprocess
+    def e(cmd):
+        r=subprocess.run(cmd,shell=True,capture_output=True,text=True)
+        return r.stdout.strip()
+    try:
+        branch=e('git rev-parse --abbrev-ref HEAD') or '?'
+        staged=int(e('git diff --cached --numstat 2>/dev/null|wc -l') or '0')
+        modified=int(e('git diff --numstat 2>/dev/null|wc -l') or '0')
+        remote=e('git remote get-url origin 2>/dev/null')
+        return [branch,staged,modified,remote]
+    except Exception: return ['?',0,0,'']
+def __cache_git(sid,ttl,run):
+    import os,json,time as _t
+    f=os.path.join(os.environ.get('TMPDIR','/tmp'),f'statusline-git-cache-{sid}')
+    try:
+        with open(f) as fp: c=json.load(fp)
+        if _t.time()-c['ts']<ttl: return c['d']
+    except Exception: pass
+    d=run()
+    try:
+        with open(f,'w') as fp: json.dump({'ts':_t.time(),'d':d},fp)
+    except Exception: pass
+    return d
+    __GIT = __cache_git(d.get('session_id','default'), 5, __run_git)
+    print(__pack([(d.get('model') or {}).get('display_name','?'), __GIT[0]], " | ", 100, False, 10))
+    except Exception:
+        print('[?]')
+
+if __name__ == '__main__':
+    main()
+"
+`;

--- a/src/codegen/emitBash.test.ts
+++ b/src/codegen/emitBash.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { emitBash } from './emitBash';
+import type { ParamId, ResolvedOptions } from '../schema/types';
+
+const opts = (): ResolvedOptions => ({
+  global: { lineLength: 100, separator: ' | ', useEmojis: true, hardLimit: false,
+    tolerancePct: 10, padding: 0, refreshInterval: null, hideVimModeIndicator: false,
+    cacheGit: true, cacheStalenessSec: 5 },
+  sub: {},
+});
+
+describe('emitBash', () => {
+  it('basic selection snapshot', () => {
+    expect(emitBash(['model_display', 'cwd', 'ctx_bar'] as ParamId[], opts())).toMatchSnapshot();
+  });
+});

--- a/src/codegen/emitBash.ts
+++ b/src/codegen/emitBash.ts
@@ -1,0 +1,34 @@
+import type { ParamId, ResolvedOptions } from '../schema/types';
+import { PARAMS_BY_ID } from '../schema/params';
+import { SH_HELPERS } from './runtimes/sh';
+import { packLines } from './pack';
+import { collectHelpers } from './fragment';
+
+export function emitBash(selected: ParamId[], opts: ResolvedOptions): string {
+  const fragments = selected.map((id) => PARAMS_BY_ID[id].render.sh(opts));
+  const widths = selected.map((id) => PARAMS_BY_ID[id].estimateWidth(opts));
+  const lineGroups = packLines(widths, opts);
+  const rawHelpers = collectHelpers(fragments);
+  const helperIds = ['__stripAnsi', '__pack', ...rawHelpers].filter(
+    (h, i, a) => a.indexOf(h) === i,
+  );
+  const helperBlock = helperIds.map((h) => SH_HELPERS[h] ?? '').join('\n');
+  const extracts = Array.from(
+    new Set(fragments.map((f) => f.extract).filter(Boolean) as string[]),
+  ).join('\n');
+
+  const lines = lineGroups
+    .map((g) => {
+      const parts = g.map((idx) => fragments[idx].expr).join(' ');
+      return `__pack ${JSON.stringify(opts.global.separator)} ${opts.global.lineLength} ${opts.global.hardLimit ? 'true' : 'false'} ${opts.global.tolerancePct} ${parts}`;
+    })
+    .join('\n');
+
+  return `#!/bin/bash
+# Requires: jq
+input=$(cat)
+${helperBlock}
+${extracts}
+${lines}
+`;
+}

--- a/src/codegen/emitJs.test.ts
+++ b/src/codegen/emitJs.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { emitJs } from './emitJs';
+import type { ParamId, ResolvedOptions } from '../schema/types';
+
+const opts = (): ResolvedOptions => ({
+  global: {
+    lineLength: 100, separator: ' | ', useEmojis: true, hardLimit: false,
+    tolerancePct: 10, padding: 0, refreshInterval: null,
+    hideVimModeIndicator: false, cacheGit: true, cacheStalenessSec: 5,
+  },
+  sub: {},
+});
+
+describe('emitJs', () => {
+  it('produces a runnable script for a basic selection', () => {
+    const ids: ParamId[] = ['model_display', 'cwd'];
+    const script = emitJs(ids, opts());
+    expect(script).toContain('#!/usr/bin/env node');
+    expect(script).toContain("process.stdin.on('end'");
+    expect(script).toMatchSnapshot();
+  });
+  it('emits ctx_bar with bar helper', () => {
+    const ids: ParamId[] = ['model_display', 'ctx_bar'];
+    const out = emitJs(ids, opts());
+    expect(out).toContain('__bar(');
+    expect(out).toMatchSnapshot();
+  });
+  it('emits git extraction block with cache when git params selected', () => {
+    const ids: ParamId[] = ['model_display', 'git_branch', 'git_modified_count'];
+    const out = emitJs(ids, opts());
+    expect(out).toContain('__cacheGit');
+    expect(out).toContain('__GIT');
+    expect(out).toMatchSnapshot();
+  });
+  it('emits resetTime helper for rate_5h_resets', () => {
+    const ids: ParamId[] = ['rate_5h_resets'];
+    const out = emitJs(ids, opts());
+    expect(out).toContain('__resetTime');
+    expect(out).toMatchSnapshot();
+  });
+});

--- a/src/codegen/emitJs.ts
+++ b/src/codegen/emitJs.ts
@@ -1,0 +1,44 @@
+import type { ParamId, ResolvedOptions } from '../schema/types';
+import { PARAMS_BY_ID } from '../schema/params';
+import { JS_HELPERS } from './runtimes/js';
+import { packLines } from './pack';
+import { collectHelpers } from './fragment';
+
+export function emitJs(selected: ParamId[], opts: ResolvedOptions): string {
+  const fragments = selected.map((id) => PARAMS_BY_ID[id].render.js(opts));
+  const widths = selected.map((id) => PARAMS_BY_ID[id].estimateWidth(opts));
+  const lineGroups = packLines(widths, opts);
+  const rawHelpers = collectHelpers(fragments);
+  const helperIds = ['__stripAnsi', '__pack', ...rawHelpers].filter(
+    (h, i, a) => a.indexOf(h) === i,
+  );
+  const helperBlock = helperIds.map((h) => JS_HELPERS[h] ?? '').join('\n    ');
+
+  const needsGit = rawHelpers.includes('__git');
+  const gitBlock = needsGit
+    ? opts.global.cacheGit
+      ? `    const __GIT = __cacheGit(d.session_id ?? 'default', ${opts.global.cacheStalenessSec}, __runGit);\n`
+      : `    const __GIT = __runGit();\n`
+    : '';
+
+  const linesCode = lineGroups
+    .map((g) => {
+      const parts = g.map((idx) => fragments[idx].expr).join(', ');
+      return `    console.log(__pack([${parts}], ${JSON.stringify(opts.global.separator)}, ${opts.global.lineLength}, ${opts.global.hardLimit}, ${opts.global.tolerancePct}));`;
+    })
+    .join('\n');
+
+  return `#!/usr/bin/env node
+let input = '';
+process.stdin.on('data', (c) => (input += c));
+process.stdin.on('end', () => {
+  try {
+    const d = JSON.parse(input);
+    ${helperBlock}
+${gitBlock}${linesCode}
+  } catch (_e) {
+    console.log('[?]');
+  }
+});
+`;
+}

--- a/src/codegen/emitPowershell.test.ts
+++ b/src/codegen/emitPowershell.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { emitPowershell } from './emitPowershell';
+import type { ParamId, ResolvedOptions } from '../schema/types';
+
+const opts = (): ResolvedOptions => ({
+  global: { lineLength: 100, separator: ' | ', useEmojis: true, hardLimit: false,
+    tolerancePct: 10, padding: 0, refreshInterval: null, hideVimModeIndicator: false,
+    cacheGit: true, cacheStalenessSec: 5 },
+  sub: {},
+});
+
+describe('emitPowershell', () => {
+  it('basic selection snapshot', () => {
+    expect(emitPowershell(['model_display', 'cwd', 'ctx_bar'] as ParamId[], opts())).toMatchSnapshot();
+  });
+});

--- a/src/codegen/emitPowershell.ts
+++ b/src/codegen/emitPowershell.ts
@@ -1,0 +1,37 @@
+import type { ParamId, ResolvedOptions } from '../schema/types';
+import { PARAMS_BY_ID } from '../schema/params';
+import { PS_HELPERS } from './runtimes/ps';
+import { packLines } from './pack';
+import { collectHelpers } from './fragment';
+
+export function emitPowershell(selected: ParamId[], opts: ResolvedOptions): string {
+  const fragments = selected.map((id) => PARAMS_BY_ID[id].render.ps(opts));
+  const widths = selected.map((id) => PARAMS_BY_ID[id].estimateWidth(opts));
+  const lineGroups = packLines(widths, opts);
+  const rawHelpers = collectHelpers(fragments);
+  const helperIds = ['Strip-Ansi', '__pack', ...rawHelpers].filter(
+    (h, i, a) => a.indexOf(h) === i,
+  );
+  const helperBlock = helperIds.map((h) => PS_HELPERS[h] ?? '').join('\n');
+  const extracts = Array.from(
+    new Set(fragments.map((f) => f.extract).filter(Boolean) as string[]),
+  ).join('\n');
+
+  const lines = lineGroups
+    .map((g) => {
+      const parts = g.map((idx) => fragments[idx].expr).join(', ');
+      return `    Write-Host (__Pack @(${parts}) ${JSON.stringify(opts.global.separator)} ${opts.global.lineLength} $${opts.global.hardLimit} ${opts.global.tolerancePct})`;
+    })
+    .join('\n');
+
+  return `$ErrorActionPreference = 'Continue'
+try {
+    $d = $input | Out-String | ConvertFrom-Json
+${helperBlock}
+${extracts}
+${lines}
+} catch {
+    Write-Host '[?]'
+}
+`;
+}

--- a/src/codegen/emitPython.test.ts
+++ b/src/codegen/emitPython.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { emitPython } from './emitPython';
+import type { ParamId, ResolvedOptions } from '../schema/types';
+
+const opts = (): ResolvedOptions => ({
+  global: { lineLength: 100, separator: ' | ', useEmojis: true, hardLimit: false,
+    tolerancePct: 10, padding: 0, refreshInterval: null, hideVimModeIndicator: false,
+    cacheGit: true, cacheStalenessSec: 5 },
+  sub: {},
+});
+
+describe('emitPython', () => {
+  it('basic selection snapshot', () => {
+    expect(emitPython(['model_display', 'cwd', 'ctx_bar'] as ParamId[], opts())).toMatchSnapshot();
+  });
+  it('git extraction block', () => {
+    const out = emitPython(['model_display', 'git_branch'] as ParamId[], opts());
+    expect(out).toContain('__GIT');
+    expect(out).toMatchSnapshot();
+  });
+});

--- a/src/codegen/emitPython.ts
+++ b/src/codegen/emitPython.ts
@@ -1,0 +1,44 @@
+import type { ParamId, ResolvedOptions } from '../schema/types';
+import { PARAMS_BY_ID } from '../schema/params';
+import { PY_HELPERS } from './runtimes/py';
+import { packLines } from './pack';
+import { collectHelpers } from './fragment';
+
+export function emitPython(selected: ParamId[], opts: ResolvedOptions): string {
+  const fragments = selected.map((id) => PARAMS_BY_ID[id].render.py(opts));
+  const widths = selected.map((id) => PARAMS_BY_ID[id].estimateWidth(opts));
+  const lineGroups = packLines(widths, opts);
+  const rawHelpers = collectHelpers(fragments);
+  const helperIds = ['__stripAnsi', '__pack', ...rawHelpers].filter(
+    (h, i, a) => a.indexOf(h) === i,
+  );
+  const helperBlock = helperIds.map((h) => PY_HELPERS[h] ?? '').join('\n');
+
+  const needsGit = rawHelpers.includes('__git');
+  const gitBlock = needsGit
+    ? opts.global.cacheGit
+      ? `    __GIT = __cache_git(d.get('session_id','default'), ${opts.global.cacheStalenessSec}, __run_git)\n`
+      : `    __GIT = __run_git()\n`
+    : '';
+
+  const lines = lineGroups
+    .map((g) => {
+      const parts = g.map((idx) => fragments[idx].expr).join(', ');
+      return `    print(__pack([${parts}], ${JSON.stringify(opts.global.separator)}, ${opts.global.lineLength}, ${opts.global.hardLimit ? 'True' : 'False'}, ${opts.global.tolerancePct}))`;
+    })
+    .join('\n');
+
+  return `#!/usr/bin/env python3
+import json, sys
+def main():
+    try:
+        d = json.load(sys.stdin)
+${helperBlock}
+${gitBlock}${lines}
+    except Exception:
+        print('[?]')
+
+if __name__ == '__main__':
+    main()
+`;
+}

--- a/src/codegen/emitSettings.test.ts
+++ b/src/codegen/emitSettings.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { emitSettings } from './emitSettings';
+import type { ResolvedOptions } from '../schema/types';
+
+const opts = (over: Partial<ResolvedOptions['global']> = {}): ResolvedOptions => ({
+  global: { lineLength: 100, separator: ' | ', useEmojis: true, hardLimit: false,
+    tolerancePct: 10, padding: 0, refreshInterval: null, hideVimModeIndicator: false,
+    cacheGit: true, cacheStalenessSec: 5, ...over },
+  sub: {},
+});
+
+describe('emitSettings', () => {
+  it('minimal posix bash', () => {
+    const out = emitSettings({ os: 'mac', format: 'sh', selected: ['model_display'] }, opts());
+    expect(out).toContain('"command": "~/.claude/statusline.sh"');
+    expect(out).not.toContain('padding');
+    expect(out).not.toContain('refreshInterval');
+  });
+  it('windows powershell command', () => {
+    const out = emitSettings({ os: 'win', format: 'ps', selected: ['model_display'] }, opts());
+    expect(out).toContain('powershell -NoProfile -File');
+    expect(out).toContain('statusline.ps1');
+  });
+  it('emits padding when non-zero', () => {
+    const out = emitSettings({ os: 'mac', format: 'sh', selected: ['model_display'] }, opts({ padding: 2 }));
+    expect(out).toContain('"padding": 2');
+  });
+  it('auto-defaults refreshInterval to 5 when timestamp param selected', () => {
+    const out = emitSettings({ os: 'mac', format: 'sh', selected: ['rate_5h_resets'] }, opts());
+    expect(out).toContain('"refreshInterval": 5');
+  });
+  it('omits refreshInterval when no time-based params', () => {
+    const out = emitSettings({ os: 'mac', format: 'sh', selected: ['model_display'] }, opts());
+    expect(out).not.toContain('refreshInterval');
+  });
+});

--- a/src/codegen/emitSettings.ts
+++ b/src/codegen/emitSettings.ts
@@ -1,0 +1,45 @@
+import type { ParamId, ResolvedOptions } from '../schema/types';
+
+export type EmitOs = 'mac' | 'linux' | 'win';
+export type EmitFmt = 'sh' | 'py' | 'js' | 'ps';
+
+export interface EmitSettingsInput {
+  os: EmitOs;
+  format: EmitFmt;
+  selected: ParamId[];
+}
+
+const TIME_TRIGGERS: ReadonlyArray<ParamId> = [
+  'rate_5h_resets', 'rate_7d_resets', 'cost_duration', 'cost_api_duration',
+  'git_branch', 'git_staged_count', 'git_modified_count', 'git_remote_link',
+];
+
+function commandFor(os: EmitOs, fmt: EmitFmt): string {
+  if (os === 'win') {
+    if (fmt === 'sh') return '~/.claude/statusline.sh';
+    if (fmt === 'ps') return 'powershell -NoProfile -File C:/Users/<you>/.claude/statusline.ps1';
+    if (fmt === 'py') return 'python C:/Users/<you>/.claude/statusline.py';
+    if (fmt === 'js') return 'node C:/Users/<you>/.claude/statusline.js';
+  }
+  if (fmt === 'sh') return '~/.claude/statusline.sh';
+  if (fmt === 'py') return '~/.claude/statusline.py';
+  if (fmt === 'js') return '~/.claude/statusline.js';
+  throw new Error(`Unsupported os/format: ${os}/${fmt}`);
+}
+
+export function emitSettings(input: EmitSettingsInput, opts: ResolvedOptions): string {
+  const obj: Record<string, unknown> = {
+    type: 'command',
+    command: commandFor(input.os, input.format),
+  };
+  if (opts.global.padding > 0) obj.padding = opts.global.padding;
+
+  let refresh = opts.global.refreshInterval;
+  if (refresh === null && input.selected.some((id) => TIME_TRIGGERS.includes(id))) {
+    refresh = 5;
+  }
+  if (refresh !== null) obj.refreshInterval = refresh;
+  if (opts.global.hideVimModeIndicator) obj.hideVimModeIndicator = true;
+
+  return JSON.stringify({ statusLine: obj }, null, 2);
+}

--- a/src/codegen/renderJs.ts
+++ b/src/codegen/renderJs.ts
@@ -1,0 +1,128 @@
+import type { RenderFn, CodeFragment } from '../schema/types';
+
+function f(helpers: string[], expr: string): CodeFragment {
+  return { helpers, expr };
+}
+
+export const RJ: Record<string, RenderFn> = {
+  // identity
+  modelDisplay: () => f([], "d.model?.display_name??'?'"),
+  modelId: () => f([], "d.model?.id??'?'"),
+  version: () => f([], "d.version??'?'"),
+  outputStyle: () => f([], "d.output_style?.name??'default'"),
+  effort: () => f([], "d.effort?.level??'?'"),
+  thinking: () => f([], "d.thinking?.enabled?'thinking:on':''"),
+  vim: (opts) => f([], opts.global.hideVimModeIndicator ? "''" : "d.vim?.mode??''"),
+  agent: () => f([], "d.agent?.name??''"),
+  sessionName: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 24;
+    return f(['__truncatePath'], `__truncatePath(d.session_name??'',${max},false)`);
+  },
+
+  // workspace
+  cwd: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 40;
+    const base = opts.sub.truncate?.basenameOnly ?? true;
+    return f(['__truncatePath'], `__truncatePath(d.workspace?.current_dir??d.cwd??'',${max},${base})`);
+  },
+  workspaceProject: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 40;
+    const base = opts.sub.truncate?.basenameOnly ?? true;
+    return f(['__truncatePath'], `__truncatePath(d.workspace?.project_dir??'',${max},${base})`);
+  },
+  workspaceAddedCount: () => f([], "(d.workspace?.added_dirs??[]).length||''"),
+  workspaceGitWorktree: () => f([], "d.workspace?.git_worktree??''"),
+  worktreeName: () => f([], "d.worktree?.name??''"),
+  worktreeBranch: () => f([], "d.worktree?.branch??''"),
+  worktreeOriginalBranch: () => f([], "d.worktree?.original_branch??''"),
+
+  // git (shell-derived — emitter injects __GIT array)
+  gitBranch: (opts) => f(
+    opts.global.cacheGit ? ['__git', '__cacheGit'] : ['__git'],
+    '__GIT[0]'
+  ),
+  gitStagedCount: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [1, 1];
+    return f(
+      opts.global.cacheGit ? ['ANSI_COLORS', '__git', '__cacheGit'] : ['ANSI_COLORS', '__git'],
+      `(__GIT[1]>0?(__GIT[1]>=${ra}?R:__GIT[1]>=${wa}?Y:G)+'S:'+__GIT[1]+X:'')`
+    );
+  },
+  gitModifiedCount: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [1, 1];
+    return f(
+      opts.global.cacheGit ? ['ANSI_COLORS', '__git', '__cacheGit'] : ['ANSI_COLORS', '__git'],
+      `(__GIT[2]>0?(__GIT[2]>=${ra}?R:__GIT[2]>=${wa}?Y:G)+'M:'+__GIT[2]+X:'')`
+    );
+  },
+  gitRemoteLink: (opts) => f(
+    opts.global.cacheGit ? ['__git', '__cacheGit'] : ['__git'],
+    "(__GIT[3]?'\\x1b]8;;'+__GIT[3]+'\\x07🔗\\x1b]8;;\\x07':'')"
+  ),
+
+  // context
+  ctxUsedPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS'], `(()=>{const _p=Math.floor(d.context_window?.used_percentage??0);return(_p>=${ra}?R:_p>=${wa}?Y:G)+_p+'%'+X})()`);
+  },
+  ctxRemainingPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS'], `(()=>{const _r=Math.floor(d.context_window?.remaining_percentage??100),_u=100-_r;return(_u>=${ra}?R:_u>=${wa}?Y:G)+_r+'% left'+X})()`);
+  },
+  ctxTotalTokens: () => f([], "((d.context_window?.total_input_tokens??0)+(d.context_window?.total_output_tokens??0)).toLocaleString()+'tok'"),
+  ctxWindowSize: () => f([], "((d.context_window?.context_window_size??0)/1000).toFixed(0)+'k ctx'"),
+  ctxBar: (opts) => {
+    const w = opts.sub.bar?.width ?? 10;
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS', '__bar'], `__bar(d.context_window?.used_percentage??0,${w},${wa},${ra})`);
+  },
+  ctxCurrentInput: () => f([], "(d.context_window?.current_usage?.input_tokens??0).toLocaleString()+'in'"),
+  ctxCacheRead: () => f([], "(d.context_window?.current_usage?.cache_read_input_tokens??0).toLocaleString()+'cr'"),
+  ctxCacheCreation: () => f([], "(d.context_window?.current_usage?.cache_creation_input_tokens??0).toLocaleString()+'cw'"),
+  exceeds200k: () => f([], "d.exceeds_200k_tokens?'!200k':''"),
+
+  // cost
+  costTotalUsd: () => f([], "'$'+(d.cost?.total_cost_usd??0).toFixed(4)"),
+  costDuration: () => f(['__duration'], "__duration(d.cost?.total_duration_ms??0)"),
+  costApiDuration: () => f(['__duration'], "__duration(d.cost?.total_api_duration_ms??0)"),
+  costLines: () => f([], "'+' + (d.cost?.total_lines_added??0) + ' -' + (d.cost?.total_lines_removed??0)"),
+
+  // rate limits
+  rate5hPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS'], `(()=>{const _p=Math.floor(d.rate_limits?.five_hour?.used_percentage??0);return(_p>=${ra}?R:_p>=${wa}?Y:G)+'5h:'+_p+'%'+X})()`);
+  },
+  rate5hBar: (opts) => {
+    const w = opts.sub.bar?.width ?? 10;
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS', '__bar'], `__bar(d.rate_limits?.five_hour?.used_percentage??0,${w},${wa},${ra})`);
+  },
+  rate5hResets: (opts) => {
+    const fmt = opts.sub.timestamp?.format ?? 'until';
+    return f(['__resetTime'], `__resetTime(d.rate_limits?.five_hour?.resets_at,${JSON.stringify(fmt)})`);
+  },
+  rate7dPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS'], `(()=>{const _p=Math.floor(d.rate_limits?.seven_day?.used_percentage??0);return(_p>=${ra}?R:_p>=${wa}?Y:G)+'7d:'+_p+'%'+X})()`);
+  },
+  rate7dBar: (opts) => {
+    const w = opts.sub.bar?.width ?? 10;
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS', '__bar'], `__bar(d.rate_limits?.seven_day?.used_percentage??0,${w},${wa},${ra})`);
+  },
+  rate7dResets: (opts) => {
+    const fmt = opts.sub.timestamp?.format ?? 'until';
+    return f(['__resetTime'], `__resetTime(d.rate_limits?.seven_day?.resets_at,${JSON.stringify(fmt)})`);
+  },
+
+  // misc
+  sessionId: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 8;
+    return f([], `(d.session_id??'').slice(0,${max})`);
+  },
+  transcriptPath: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 30;
+    const base = opts.sub.truncate?.basenameOnly ?? true;
+    return f(['__truncatePath'], `__truncatePath(d.transcript_path??'',${max},${base})`);
+  },
+};

--- a/src/codegen/renderPs.ts
+++ b/src/codegen/renderPs.ts
@@ -1,0 +1,147 @@
+import type { RenderFn, CodeFragment } from '../schema/types';
+
+function f(helpers: string[], expr: string, extract?: string): CodeFragment {
+  return { helpers, expr, extract };
+}
+
+export const RPS: Record<string, RenderFn> = {
+  modelDisplay: () => f([], '$MODEL_DISPLAY', '$MODEL_DISPLAY=if($d.model.display_name){$d.model.display_name}else{"?"}'),
+  modelId: () => f([], '$MODEL_ID', '$MODEL_ID=if($d.model.id){$d.model.id}else{"?"}'),
+  version: () => f([], '$SL_VERSION', '$SL_VERSION=if($d.version){$d.version}else{"?"}'),
+  outputStyle: () => f([], '$OUTPUT_STYLE', '$OUTPUT_STYLE=if($d.output_style.name){$d.output_style.name}else{"default"}'),
+  effort: () => f([], '$EFFORT', '$EFFORT=if($d.effort.level){$d.effort.level}else{"?"}'),
+  thinking: () => f([], '$THINKING', '$THINKING=if($d.thinking.enabled){"thinking:on"}else{""}'),
+  vim: (opts) => opts.global.hideVimModeIndicator
+    ? f([], '""')
+    : f([], '$VIM_MODE', '$VIM_MODE=if($d.vim.mode){$d.vim.mode}else{""}'),
+  agent: () => f([], '$AGENT_NAME', '$AGENT_NAME=if($d.agent.name){$d.agent.name}else{""}'),
+  sessionName: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 24;
+    return f(
+      ['__truncatePath'],
+      `(__TruncatePath $SESSION_NAME ${max} $false)`,
+      `$SESSION_NAME=if($d.session_name){$d.session_name}else{""}`,
+    );
+  },
+
+  cwd: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 40;
+    const base = opts.sub.truncate?.basenameOnly ?? true;
+    return f(
+      ['__truncatePath'],
+      `(__TruncatePath $CWD_RAW ${max} $${base})`,
+      `$CWD_RAW=if($d.workspace.current_dir){$d.workspace.current_dir}elseif($d.cwd){$d.cwd}else{""}`,
+    );
+  },
+  workspaceProject: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 40;
+    const base = opts.sub.truncate?.basenameOnly ?? true;
+    return f(
+      ['__truncatePath'],
+      `(__TruncatePath $WS_PROJECT ${max} $${base})`,
+      `$WS_PROJECT=if($d.workspace.project_dir){$d.workspace.project_dir}else{""}`,
+    );
+  },
+  workspaceAddedCount: () => f([], '$WS_ADDED_COUNT', '$WS_ADDED_CNT=if($d.workspace.added_dirs){$d.workspace.added_dirs.Count}else{0}; $WS_ADDED_COUNT=if($WS_ADDED_CNT -gt 0){$WS_ADDED_CNT}else{""}'),
+  workspaceGitWorktree: () => f([], '$WS_GIT_WT', '$WS_GIT_WT=if($d.workspace.git_worktree){$d.workspace.git_worktree}else{""}'),
+  worktreeName: () => f([], '$WT_NAME', '$WT_NAME=if($d.worktree.name){$d.worktree.name}else{""}'),
+  worktreeBranch: () => f([], '$WT_BRANCH', '$WT_BRANCH=if($d.worktree.branch){$d.worktree.branch}else{""}'),
+  worktreeOriginalBranch: () => f([], '$WT_ORIG_BRANCH', '$WT_ORIG_BRANCH=if($d.worktree.original_branch){$d.worktree.original_branch}else{""}'),
+
+  gitBranch: (opts) => f(
+    opts.global.cacheGit ? ['__git', '__cacheGit'] : ['__git'],
+    '$GIT_BRANCH',
+    '$_GIT=__RunGit(); $GIT_BRANCH=$_GIT[0]; $GIT_STAGED=[int]$_GIT[1]; $GIT_MODIFIED=[int]$_GIT[2]; $GIT_REMOTE=$_GIT[3]',
+  ),
+  gitStagedCount: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [1, 1];
+    return f(
+      opts.global.cacheGit ? ['ANSI_COLORS', '__git', '__cacheGit'] : ['ANSI_COLORS', '__git'],
+      `(if($GIT_STAGED -gt 0){if($GIT_STAGED -ge ${ra}){$R}elseif($GIT_STAGED -ge ${wa}){$Y}else{$G};"S:$GIT_STAGED$X"}else{""})`,
+      '$_GIT=__RunGit(); $GIT_BRANCH=$_GIT[0]; $GIT_STAGED=[int]$_GIT[1]; $GIT_MODIFIED=[int]$_GIT[2]; $GIT_REMOTE=$_GIT[3]',
+    );
+  },
+  gitModifiedCount: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [1, 1];
+    return f(
+      opts.global.cacheGit ? ['ANSI_COLORS', '__git', '__cacheGit'] : ['ANSI_COLORS', '__git'],
+      `(if($GIT_MODIFIED -gt 0){if($GIT_MODIFIED -ge ${ra}){$R}elseif($GIT_MODIFIED -ge ${wa}){$Y}else{$G};"M:$GIT_MODIFIED$X"}else{""})`,
+      '$_GIT=__RunGit(); $GIT_BRANCH=$_GIT[0]; $GIT_STAGED=[int]$_GIT[1]; $GIT_MODIFIED=[int]$_GIT[2]; $GIT_REMOTE=$_GIT[3]',
+    );
+  },
+  gitRemoteLink: (opts) => f(
+    opts.global.cacheGit ? ['__git', '__cacheGit'] : ['__git'],
+    '(if($GIT_REMOTE){"$ESC]8;;$GIT_REMOTE$([char]7)🔗$ESC]8;;$([char]7)"}else{""})',
+    '$_GIT=__RunGit(); $GIT_BRANCH=$_GIT[0]; $GIT_STAGED=[int]$_GIT[1]; $GIT_MODIFIED=[int]$_GIT[2]; $GIT_REMOTE=$_GIT[3]',
+  ),
+
+  ctxUsedPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(
+      ['ANSI_COLORS'],
+      `(& { $p=[int]($d.context_window.used_percentage ?? 0); if($p -ge ${ra}){$R}elseif($p -ge ${wa}){$Y}else{$G}; "$p%$X" })`,
+      '$CTX_USED=[int]($d.context_window.used_percentage ?? 0)',
+    );
+  },
+  ctxRemainingPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(
+      ['ANSI_COLORS'],
+      `(& { $r=[int]($d.context_window.remaining_percentage ?? 100); $u=100-$r; if($u -ge ${ra}){$R}elseif($u -ge ${wa}){$Y}else{$G}; "$r% left$X" })`,
+      '$CTX_REM=[int]($d.context_window.remaining_percentage ?? 100)',
+    );
+  },
+  ctxTotalTokens: () => f([], '"$(($d.context_window.total_input_tokens ?? 0)+($d.context_window.total_output_tokens ?? 0))tok"'),
+  ctxWindowSize: () => f([], '"$([int](($d.context_window.context_window_size ?? 0)/1000))k ctx"'),
+  ctxBar: (opts) => {
+    const w = opts.sub.bar?.width ?? 10;
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS', '__bar'], `(__Bar ([int]($d.context_window.used_percentage ?? 0)) ${w} ${wa} ${ra})`);
+  },
+  ctxCurrentInput: () => f([], '"$(($d.context_window.current_usage.input_tokens ?? 0))in"'),
+  ctxCacheRead: () => f([], '"$(($d.context_window.current_usage.cache_read_input_tokens ?? 0))cr"'),
+  ctxCacheCreation: () => f([], '"$(($d.context_window.current_usage.cache_creation_input_tokens ?? 0))cw"'),
+  exceeds200k: () => f([], '(if($d.exceeds_200k_tokens){"!200k"}else{""})'),
+
+  costTotalUsd: () => f([], '"$" + ("{0:F4}" -f ($d.cost.total_cost_usd ?? 0))'),
+  costDuration: () => f(['__duration'], '(__Duration ($d.cost.total_duration_ms ?? 0))'),
+  costApiDuration: () => f(['__duration'], '(__Duration ($d.cost.total_api_duration_ms ?? 0))'),
+  costLines: () => f([], '"+$($d.cost.total_lines_added ?? 0) -$($d.cost.total_lines_removed ?? 0)"'),
+
+  rate5hPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS'], `(& { $p=[int]($d.rate_limits.five_hour.used_percentage ?? 0); if($p -ge ${ra}){$R}elseif($p -ge ${wa}){$Y}else{$G}; "5h:$p%$X" })`);
+  },
+  rate5hBar: (opts) => {
+    const w = opts.sub.bar?.width ?? 10;
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS', '__bar'], `(__Bar ([int]($d.rate_limits.five_hour.used_percentage ?? 0)) ${w} ${wa} ${ra})`);
+  },
+  rate5hResets: (opts) => {
+    const fmt = opts.sub.timestamp?.format ?? 'until';
+    return f(['__resetTime'], `(__ResetTime ($d.rate_limits.five_hour.resets_at ?? 0) ${JSON.stringify(fmt)})`);
+  },
+  rate7dPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS'], `(& { $p=[int]($d.rate_limits.seven_day.used_percentage ?? 0); if($p -ge ${ra}){$R}elseif($p -ge ${wa}){$Y}else{$G}; "7d:$p%$X" })`);
+  },
+  rate7dBar: (opts) => {
+    const w = opts.sub.bar?.width ?? 10;
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS', '__bar'], `(__Bar ([int]($d.rate_limits.seven_day.used_percentage ?? 0)) ${w} ${wa} ${ra})`);
+  },
+  rate7dResets: (opts) => {
+    const fmt = opts.sub.timestamp?.format ?? 'until';
+    return f(['__resetTime'], `(__ResetTime ($d.rate_limits.seven_day.resets_at ?? 0) ${JSON.stringify(fmt)})`);
+  },
+
+  sessionId: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 8;
+    return f([], `(if($d.session_id){$d.session_id.Substring(0,[Math]::Min(${max},$d.session_id.Length))}else{""})`);
+  },
+  transcriptPath: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 30;
+    const base = opts.sub.truncate?.basenameOnly ?? true;
+    return f(['__truncatePath'], `(__TruncatePath ($d.transcript_path ?? "") ${max} $${base})`);
+  },
+};

--- a/src/codegen/renderPy.ts
+++ b/src/codegen/renderPy.ts
@@ -1,0 +1,128 @@
+import type { RenderFn, CodeFragment } from '../schema/types';
+
+function f(helpers: string[], expr: string): CodeFragment {
+  return { helpers, expr };
+}
+
+export const RPY: Record<string, RenderFn> = {
+  // identity
+  modelDisplay: () => f([], "(d.get('model') or {}).get('display_name','?')"),
+  modelId: () => f([], "(d.get('model') or {}).get('id','?')"),
+  version: () => f([], "d.get('version','?')"),
+  outputStyle: () => f([], "(d.get('output_style') or {}).get('name','default')"),
+  effort: () => f([], "(d.get('effort') or {}).get('level','?')"),
+  thinking: () => f([], "'thinking:on' if (d.get('thinking') or {}).get('enabled') else ''"),
+  vim: (opts) => f([], opts.global.hideVimModeIndicator ? "''" : "(d.get('vim') or {}).get('mode','')"),
+  agent: () => f([], "(d.get('agent') or {}).get('name','')"),
+  sessionName: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 24;
+    return f(['__truncatePath'], `__truncate_path(d.get('session_name',''),${max},False)`);
+  },
+
+  // workspace
+  cwd: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 40;
+    const base = opts.sub.truncate?.basenameOnly ?? true;
+    return f(['__truncatePath'], `__truncate_path((d.get('workspace') or {}).get('current_dir','') or d.get('cwd',''),${max},${base ? 'True' : 'False'})`);
+  },
+  workspaceProject: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 40;
+    const base = opts.sub.truncate?.basenameOnly ?? true;
+    return f(['__truncatePath'], `__truncate_path((d.get('workspace') or {}).get('project_dir',''),${max},${base ? 'True' : 'False'})`);
+  },
+  workspaceAddedCount: () => f([], "len((d.get('workspace') or {}).get('added_dirs',[]))or''"),
+  workspaceGitWorktree: () => f([], "(d.get('workspace') or {}).get('git_worktree','')"),
+  worktreeName: () => f([], "(d.get('worktree') or {}).get('name','')"),
+  worktreeBranch: () => f([], "(d.get('worktree') or {}).get('branch','')"),
+  worktreeOriginalBranch: () => f([], "(d.get('worktree') or {}).get('original_branch','')"),
+
+  // git
+  gitBranch: (opts) => f(
+    opts.global.cacheGit ? ['__git', '__cacheGit'] : ['__git'],
+    '__GIT[0]',
+  ),
+  gitStagedCount: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [1, 1];
+    return f(
+      opts.global.cacheGit ? ['ANSI_COLORS', '__git', '__cacheGit'] : ['ANSI_COLORS', '__git'],
+      `(f'{{R if __GIT[1]>=${ra} else Y if __GIT[1]>=${wa} else G}}S:{{__GIT[1]}}{{X}}' if __GIT[1]>0 else '')`,
+    );
+  },
+  gitModifiedCount: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [1, 1];
+    return f(
+      opts.global.cacheGit ? ['ANSI_COLORS', '__git', '__cacheGit'] : ['ANSI_COLORS', '__git'],
+      `(f'{{R if __GIT[2]>=${ra} else Y if __GIT[2]>=${wa} else G}}M:{{__GIT[2]}}{{X}}' if __GIT[2]>0 else '')`,
+    );
+  },
+  gitRemoteLink: (opts) => f(
+    opts.global.cacheGit ? ['__git', '__cacheGit'] : ['__git'],
+    "(f'\\x1b]8;;{__GIT[3]}\\x07🔗\\x1b]8;;\\x07' if __GIT[3] else '')",
+  ),
+
+  // context
+  ctxUsedPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS'], `(lambda p:f'{{R if p>=${ra} else Y if p>=${wa} else G}}{{p}}%{{X}}')(int((d.get('context_window') or {}).get('used_percentage',0)))`);
+  },
+  ctxRemainingPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS'], `(lambda r,u:(f'{{R if u>=${ra} else Y if u>=${wa} else G}}{{r}}% left{{X}}'))(int((d.get('context_window') or {}).get('remaining_percentage',100)),100-int((d.get('context_window') or {}).get('remaining_percentage',100)))`);
+  },
+  ctxTotalTokens: () => f([], "f\"{(d.get('context_window') or {}).get('total_input_tokens',0)+(d.get('context_window') or {}).get('total_output_tokens',0)}tok\""),
+  ctxWindowSize: () => f([], "f\"{(d.get('context_window') or {}).get('context_window_size',0)//1000}k ctx\""),
+  ctxBar: (opts) => {
+    const w = opts.sub.bar?.width ?? 10;
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS', '__bar'], `__bar((d.get('context_window') or {}).get('used_percentage',0),${w},${wa},${ra})`);
+  },
+  ctxCurrentInput: () => f([], "f\"{(d.get('context_window') or {}).get('current_usage',{}).get('input_tokens',0)}in\""),
+  ctxCacheRead: () => f([], "f\"{(d.get('context_window') or {}).get('current_usage',{}).get('cache_read_input_tokens',0)}cr\""),
+  ctxCacheCreation: () => f([], "f\"{(d.get('context_window') or {}).get('current_usage',{}).get('cache_creation_input_tokens',0)}cw\""),
+  exceeds200k: () => f([], "('!200k' if d.get('exceeds_200k_tokens') else '')"),
+
+  // cost
+  costTotalUsd: () => f([], "f\"${(d.get('cost') or {}).get('total_cost_usd',0):.4f}\""),
+  costDuration: () => f(['__duration'], "__duration((d.get('cost') or {}).get('total_duration_ms',0))"),
+  costApiDuration: () => f(['__duration'], "__duration((d.get('cost') or {}).get('total_api_duration_ms',0))"),
+  costLines: () => f([], "f\"+{(d.get('cost') or {}).get('total_lines_added',0)} -{(d.get('cost') or {}).get('total_lines_removed',0)}\""),
+
+  // rate limits
+  rate5hPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS'], `(lambda p:f'{{R if p>=${ra} else Y if p>=${wa} else G}}5h:{{p}}%{{X}}')(int((d.get('rate_limits') or {}).get('five_hour',{}).get('used_percentage',0)))`);
+  },
+  rate5hBar: (opts) => {
+    const w = opts.sub.bar?.width ?? 10;
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS', '__bar'], `__bar((d.get('rate_limits') or {}).get('five_hour',{}).get('used_percentage',0),${w},${wa},${ra})`);
+  },
+  rate5hResets: (opts) => {
+    const fmt = opts.sub.timestamp?.format ?? 'until';
+    return f(['__resetTime'], `__reset_time((d.get('rate_limits') or {}).get('five_hour',{}).get('resets_at'),${JSON.stringify(fmt)})`);
+  },
+  rate7dPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS'], `(lambda p:f'{{R if p>=${ra} else Y if p>=${wa} else G}}7d:{{p}}%{{X}}')(int((d.get('rate_limits') or {}).get('seven_day',{}).get('used_percentage',0)))`);
+  },
+  rate7dBar: (opts) => {
+    const w = opts.sub.bar?.width ?? 10;
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(['ANSI_COLORS', '__bar'], `__bar((d.get('rate_limits') or {}).get('seven_day',{}).get('used_percentage',0),${w},${wa},${ra})`);
+  },
+  rate7dResets: (opts) => {
+    const fmt = opts.sub.timestamp?.format ?? 'until';
+    return f(['__resetTime'], `__reset_time((d.get('rate_limits') or {}).get('seven_day',{}).get('resets_at'),${JSON.stringify(fmt)})`);
+  },
+
+  // misc
+  sessionId: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 8;
+    return f([], `(d.get('session_id',''))[:${max}]`);
+  },
+  transcriptPath: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 30;
+    const base = opts.sub.truncate?.basenameOnly ?? true;
+    return f(['__truncatePath'], `__truncate_path(d.get('transcript_path',''),${max},${base ? 'True' : 'False'})`);
+  },
+};

--- a/src/codegen/renderSh.ts
+++ b/src/codegen/renderSh.ts
@@ -1,0 +1,185 @@
+import type { RenderFn, CodeFragment } from '../schema/types';
+
+function f(helpers: string[], expr: string, extract?: string): CodeFragment {
+  return { helpers, expr, extract };
+}
+
+export const RSH: Record<string, RenderFn> = {
+  modelDisplay: () => f([], '"${MODEL_DISPLAY}"', 'MODEL_DISPLAY=$(echo "$input"|jq -r \'.model.display_name//"?"\')'),
+  modelId: () => f([], '"${MODEL_ID}"', 'MODEL_ID=$(echo "$input"|jq -r \'.model.id//"?"\')'),
+  version: () => f([], '"${SL_VERSION}"', 'SL_VERSION=$(echo "$input"|jq -r \'.version//"?"\')'),
+  outputStyle: () => f([], '"${OUTPUT_STYLE}"', 'OUTPUT_STYLE=$(echo "$input"|jq -r \'.output_style.name//"default"\')'),
+  effort: () => f([], '"${EFFORT}"', 'EFFORT=$(echo "$input"|jq -r \'.effort.level//"?"\')'),
+  thinking: () => f([], '"${THINKING}"', 'THINKING=$(echo "$input"|jq -r \'if .thinking.enabled then "thinking:on" else "" end\')'),
+  vim: (opts) => opts.global.hideVimModeIndicator
+    ? f([], '""')
+    : f([], '"${VIM_MODE}"', 'VIM_MODE=$(echo "$input"|jq -r \'.vim.mode//empty\')'),
+  agent: () => f([], '"${AGENT_NAME}"', 'AGENT_NAME=$(echo "$input"|jq -r \'.agent.name//empty\')'),
+  sessionName: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 24;
+    return f(
+      ['__truncatePath'],
+      `"$(__truncate_path "$(echo "$input"|jq -r '.session_name//empty')" ${max} 0)"`,
+      `SESSION_NAME=$(echo "$input"|jq -r '.session_name//empty')`,
+    );
+  },
+
+  cwd: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 40;
+    const base = opts.sub.truncate?.basenameOnly ?? true ? '1' : '0';
+    return f(
+      ['__truncatePath'],
+      `"$(__truncate_path "\${CWD_RAW}" ${max} ${base})"`,
+      'CWD_RAW=$(echo "$input"|jq -r \'.workspace.current_dir//(.cwd//"")\')');
+  },
+  workspaceProject: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 40;
+    const base = opts.sub.truncate?.basenameOnly ?? true ? '1' : '0';
+    return f(
+      ['__truncatePath'],
+      `"$(__truncate_path "\${WS_PROJECT}" ${max} ${base})"`,
+      'WS_PROJECT=$(echo "$input"|jq -r \'.workspace.project_dir//empty\')');
+  },
+  workspaceAddedCount: () => f([], '"${WS_ADDED_COUNT}"', 'WS_ADDED_COUNT=$(echo "$input"|jq -r \'(.workspace.added_dirs//[])|length|if .==0 then "" else tostring end\')'),
+  workspaceGitWorktree: () => f([], '"${WS_GIT_WT}"', 'WS_GIT_WT=$(echo "$input"|jq -r \'.workspace.git_worktree//empty\')'),
+  worktreeName: () => f([], '"${WT_NAME}"', 'WT_NAME=$(echo "$input"|jq -r \'.worktree.name//empty\')'),
+  worktreeBranch: () => f([], '"${WT_BRANCH}"', 'WT_BRANCH=$(echo "$input"|jq -r \'.worktree.branch//empty\')'),
+  worktreeOriginalBranch: () => f([], '"${WT_ORIG_BRANCH}"', 'WT_ORIG_BRANCH=$(echo "$input"|jq -r \'.worktree.original_branch//empty\')'),
+
+  gitBranch: (opts) => f(
+    opts.global.cacheGit ? ['__git', '__cacheGit'] : ['__git'],
+    '"${GIT_BRANCH}"',
+    'GIT_INFO=$(__run_git); GIT_BRANCH=$(echo "$GIT_INFO"|sed -n \'1p\'); GIT_STAGED=$(echo "$GIT_INFO"|sed -n \'2p\'); GIT_MODIFIED=$(echo "$GIT_INFO"|sed -n \'3p\'); GIT_REMOTE=$(echo "$GIT_INFO"|sed -n \'4p\')',
+  ),
+  gitStagedCount: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [1, 1];
+    const GS = '"${GIT_STAGED}"';
+    const GS0 = '"${GIT_STAGED:-0}"';
+    return f(
+      opts.global.cacheGit ? ['ANSI_COLORS', '__git', '__cacheGit'] : ['ANSI_COLORS', '__git'],
+      `"$([ ${GS0} -gt 0 ] && printf "%s" "$([ ${GS} -ge ${ra} ] && printf "$R" || [ ${GS} -ge ${wa} ] && printf "$Y" || printf "$G")S:${GS}$X")"`,
+      'GIT_INFO=$(__run_git); GIT_BRANCH=$(echo "$GIT_INFO"|sed -n \'1p\'); GIT_STAGED=$(echo "$GIT_INFO"|sed -n \'2p\'); GIT_MODIFIED=$(echo "$GIT_INFO"|sed -n \'3p\'); GIT_REMOTE=$(echo "$GIT_INFO"|sed -n \'4p\')',
+    );
+  },
+  gitModifiedCount: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [1, 1];
+    const GM = '"${GIT_MODIFIED}"';
+    const GM0 = '"${GIT_MODIFIED:-0}"';
+    return f(
+      opts.global.cacheGit ? ['ANSI_COLORS', '__git', '__cacheGit'] : ['ANSI_COLORS', '__git'],
+      `"$([ ${GM0} -gt 0 ] && printf "%s" "$([ ${GM} -ge ${ra} ] && printf "$R" || [ ${GM} -ge ${wa} ] && printf "$Y" || printf "$G")M:${GM}$X")"`,
+      'GIT_INFO=$(__run_git); GIT_BRANCH=$(echo "$GIT_INFO"|sed -n \'1p\'); GIT_STAGED=$(echo "$GIT_INFO"|sed -n \'2p\'); GIT_MODIFIED=$(echo "$GIT_INFO"|sed -n \'3p\'); GIT_REMOTE=$(echo "$GIT_INFO"|sed -n \'4p\')',
+    );
+  },
+  gitRemoteLink: (opts) => f(
+    opts.global.cacheGit ? ['__git', '__cacheGit'] : ['__git'],
+    '"$([ -n "${GIT_REMOTE}" ] && printf "\\e]8;;%s\\e\\\\🔗\\e]8;;\\e\\\\" "${GIT_REMOTE}")"',
+    'GIT_INFO=$(__run_git); GIT_BRANCH=$(echo "$GIT_INFO"|sed -n \'1p\'); GIT_STAGED=$(echo "$GIT_INFO"|sed -n \'2p\'); GIT_MODIFIED=$(echo "$GIT_INFO"|sed -n \'3p\'); GIT_REMOTE=$(echo "$GIT_INFO"|sed -n \'4p\')',
+  ),
+
+  ctxUsedPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(
+      ['ANSI_COLORS'],
+      `"$(CTX_PCT=$(echo "$input"|jq -r '.context_window.used_percentage//0|floor'); [ "$CTX_PCT" -ge ${ra} ] && printf "$R" || [ "$CTX_PCT" -ge ${wa} ] && printf "$Y" || printf "$G"; printf "%s%%%s" "$CTX_PCT" "$X")"`,
+      'CTX_USED=$(echo "$input"|jq -r \'.context_window.used_percentage//0|floor\')',
+    );
+  },
+  ctxRemainingPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(
+      ['ANSI_COLORS'],
+      `"$(CTX_REM=$(echo "$input"|jq -r '.context_window.remaining_percentage//100|floor'); CTX_U=$((100-CTX_REM)); [ "$CTX_U" -ge ${ra} ] && printf "$R" || [ "$CTX_U" -ge ${wa} ] && printf "$Y" || printf "$G"; printf "%s%% left%s" "$CTX_REM" "$X")"`,
+      'CTX_REM=$(echo "$input"|jq -r \'.context_window.remaining_percentage//100|floor\')',
+    );
+  },
+  ctxTotalTokens: () => f([], '"${CTX_TOTAL_TOK}tok"', 'CTX_TOTAL_TOK=$(echo "$input"|jq -r \'(.context_window.total_input_tokens//0)+(.context_window.total_output_tokens//0)\')'),
+  ctxWindowSize: () => f([], '"${CTX_WIN_SIZE}k ctx"', 'CTX_WIN_SIZE=$(echo "$input"|jq -r \'(.context_window.context_window_size//0)/1000|floor\')'),
+  ctxBar: (opts) => {
+    const w = opts.sub.bar?.width ?? 10;
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(
+      ['ANSI_COLORS', '__bar'],
+      `"$(__bar "\${CTX_BAR_PCT}" ${w} ${wa} ${ra})"`,
+      'CTX_BAR_PCT=$(echo "$input"|jq -r \'.context_window.used_percentage//0|floor\')',
+    );
+  },
+  ctxCurrentInput: () => f([], '"${CTX_CUR_IN}in"', 'CTX_CUR_IN=$(echo "$input"|jq -r \'.context_window.current_usage.input_tokens//0\')'),
+  ctxCacheRead: () => f([], '"${CTX_CR}cr"', 'CTX_CR=$(echo "$input"|jq -r \'.context_window.current_usage.cache_read_input_tokens//0\')'),
+  ctxCacheCreation: () => f([], '"${CTX_CW}cw"', 'CTX_CW=$(echo "$input"|jq -r \'.context_window.current_usage.cache_creation_input_tokens//0\')'),
+  exceeds200k: () => f([], '"$(echo "$input"|jq -r \'if .exceeds_200k_tokens then "!200k" else "" end\')"'),
+
+  costTotalUsd: () => f([], '"$$(echo "$input"|jq -r \'.cost.total_cost_usd//0|.*10000|round/10000\')"'),
+  costDuration: () => f(['__duration'], '"$(__duration "$(echo "$input"|jq -r \'.cost.total_duration_ms//0\')")"'),
+  costApiDuration: () => f(['__duration'], '"$(__duration "$(echo "$input"|jq -r \'.cost.total_api_duration_ms//0\')")"'),
+  costLines: () => f([], '"+$(echo "$input"|jq -r \'.cost.total_lines_added//0\') -$(echo "$input"|jq -r \'.cost.total_lines_removed//0\')"'),
+
+  rate5hPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(
+      ['ANSI_COLORS'],
+      `"$(P5H=$(echo "$input"|jq -r '.rate_limits.five_hour.used_percentage//0|floor'); [ "$P5H" -ge ${ra} ] && printf "$R" || [ "$P5H" -ge ${wa} ] && printf "$Y" || printf "$G"; printf "5h:%s%%%s" "$P5H" "$X")"`,
+      'P5H=$(echo "$input"|jq -r \'.rate_limits.five_hour.used_percentage//0|floor\')',
+    );
+  },
+  rate5hBar: (opts) => {
+    const w = opts.sub.bar?.width ?? 10;
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(
+      ['ANSI_COLORS', '__bar'],
+      `"$(__bar "$(echo "$input"|jq -r '.rate_limits.five_hour.used_percentage//0|floor')" ${w} ${wa} ${ra})"`,
+      'R5H_PCT=$(echo "$input"|jq -r \'.rate_limits.five_hour.used_percentage//0|floor\')',
+    );
+  },
+  rate5hResets: (opts) => {
+    const fmt = opts.sub.timestamp?.format ?? 'until';
+    return f(
+      ['__resetTime'],
+      `"$(__reset_time "$(echo "$input"|jq -r '.rate_limits.five_hour.resets_at//0')" "${fmt}")"`,
+      'R5H_TS=$(echo "$input"|jq -r \'.rate_limits.five_hour.resets_at//0\')',
+    );
+  },
+  rate7dPct: (opts) => {
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(
+      ['ANSI_COLORS'],
+      `"$(P7D=$(echo "$input"|jq -r '.rate_limits.seven_day.used_percentage//0|floor'); [ "$P7D" -ge ${ra} ] && printf "$R" || [ "$P7D" -ge ${wa} ] && printf "$Y" || printf "$G"; printf "7d:%s%%%s" "$P7D" "$X")"`,
+      'P7D=$(echo "$input"|jq -r \'.rate_limits.seven_day.used_percentage//0|floor\')',
+    );
+  },
+  rate7dBar: (opts) => {
+    const w = opts.sub.bar?.width ?? 10;
+    const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
+    return f(
+      ['ANSI_COLORS', '__bar'],
+      `"$(__bar "$(echo "$input"|jq -r '.rate_limits.seven_day.used_percentage//0|floor')" ${w} ${wa} ${ra})"`,
+      'R7D_PCT=$(echo "$input"|jq -r \'.rate_limits.seven_day.used_percentage//0|floor\')',
+    );
+  },
+  rate7dResets: (opts) => {
+    const fmt = opts.sub.timestamp?.format ?? 'until';
+    return f(
+      ['__resetTime'],
+      `"$(__reset_time "$(echo "$input"|jq -r '.rate_limits.seven_day.resets_at//0')" "${fmt}")"`,
+      'R7D_TS=$(echo "$input"|jq -r \'.rate_limits.seven_day.resets_at//0\')',
+    );
+  },
+
+  sessionId: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 8;
+    return f(
+      [],
+      `"$(echo "$input"|jq -r '.session_id//empty'|head -c ${max})"`,
+      `SID=$(echo "$input"|jq -r '.session_id//empty'|head -c ${max})`,
+    );
+  },
+  transcriptPath: (opts) => {
+    const max = opts.sub.truncate?.maxChars ?? 30;
+    const base = opts.sub.truncate?.basenameOnly ?? true ? '1' : '0';
+    return f(
+      ['__truncatePath'],
+      `"$(__truncate_path "$(echo "$input"|jq -r '.transcript_path//empty')" ${max} ${base})"`,
+      'TRANSCRIPT=$(echo "$input"|jq -r \'.transcript_path//empty\')',
+    );
+  },
+};

--- a/src/codegen/runtimes/js.ts
+++ b/src/codegen/runtimes/js.ts
@@ -1,0 +1,19 @@
+export const JS_HELPERS: Record<string, string> = {
+  ANSI_COLORS: `const G='\\x1b[32m',Y='\\x1b[33m',R='\\x1b[31m',C='\\x1b[36m',X='\\x1b[0m';`,
+
+  __stripAnsi: `const __stripAnsi=(s)=>String(s).replace(/\\x1b\\[[0-9;]*m/g,'').replace(/\\x1b\\]8;;[^\\x07]*\\x07/g,'');`,
+
+  __bar: `const __bar=(pct,w=10,wa=75,ra=90)=>{const f=Math.round((pct/100)*w),b='\\u2593'.repeat(Math.max(0,f))+'\\u2591'.repeat(Math.max(0,w-f)),c=pct>=ra?R:pct>=wa?Y:G;return c+b+X};`,
+
+  __resetTime: `const __resetTime=(epoch,fmt='until')=>{if(!epoch)return'?';const dt=new Date(epoch*1e3),now=new Date(),diff=Math.max(0,dt-now),pad=n=>String(n).padStart(2,'0');if(fmt==='until'){const h=Math.floor(diff/36e5),m=Math.floor((diff%36e5)/6e4);return h>0?h+'h '+m+'m':m+'m'}if(fmt==='YYYY-MM-DD')return dt.getFullYear()+'-'+pad(dt.getMonth()+1)+'-'+pad(dt.getDate());if(fmt==='DD/MM/YY')return pad(dt.getDate())+'/'+pad(dt.getMonth()+1)+'/'+String(dt.getFullYear()).slice(2);if(fmt==='HH:mm')return pad(dt.getHours())+':'+pad(dt.getMinutes());return String(epoch)};`,
+
+  __truncatePath: `const __truncatePath=(p,max=40,base=false)=>{if(!p)return'';const s=base?(String(p).split('/').pop()||p):String(p);return s.length<=max?s:'\\u2026'+s.slice(-(max-1))};`,
+
+  __duration: `const __duration=(ms=0)=>{const s=Math.floor(ms/1e3),m=Math.floor(s/60),sc=s%60;return m>0?m+'m '+sc+'s':sc+'s'};`,
+
+  __pack: `const __pack=(parts,sep=' | ',max=100,hard=false,tol=10)=>{const ps=parts.filter(x=>x!=null&&x!=='');if(!ps.length)return'';const lim=hard?max:max*(1+tol/100),lines=[[]];let run=0;for(const p of ps){const l=__stripAnsi(String(p)).length,add=l+(lines[lines.length-1].length?sep.length:0);if(lines[lines.length-1].length&&run+add>lim){lines.push([p]);run=l}else{lines[lines.length-1].push(p);run+=add}}return lines.map(l=>l.join(sep)).join('\\n')};`,
+
+  __cacheGit: `const __cacheGit=(sid,ttl,run)=>{const os=require('os'),fs=require('fs'),f=os.tmpdir()+'/statusline-git-cache-'+sid;try{const c=JSON.parse(fs.readFileSync(f,'utf8'));if(Date.now()-c.ts<ttl*1e3)return c.d}catch(e){}const d=run();try{fs.writeFileSync(f,JSON.stringify({ts:Date.now(),d}))}catch(e){}return d};`,
+
+  __git: `const __runGit=()=>{try{const ex=(cmd)=>require('child_process').execSync(cmd,{stdio:['ignore','pipe','ignore'],encoding:'utf8'}).trim();const branch=ex('git rev-parse --abbrev-ref HEAD');const staged=parseInt(ex('git diff --cached --numstat 2>/dev/null|wc -l')||'0',10);const modified=parseInt(ex('git diff --numstat 2>/dev/null|wc -l')||'0',10);let remote='';try{remote=ex('git remote get-url origin 2>/dev/null')}catch(_){}return[branch,staged,modified,remote]}catch(_){return['?',0,0,'']}};`,
+};

--- a/src/codegen/runtimes/ps.ts
+++ b/src/codegen/runtimes/ps.ts
@@ -1,0 +1,66 @@
+export const PS_HELPERS: Record<string, string> = {
+  ANSI_COLORS: `$ESC=if($PSVersionTable.PSVersion.Major -ge 7){"$([char]27)"}else{[char]27}
+$G="$ESC[32m"; $Y="$ESC[33m"; $R="$ESC[31m"; $C="$ESC[36m"; $X="$ESC[0m"`,
+
+  __stripAnsi: `function Strip-Ansi($s){ $s -replace '\x1b\[[0-9;]*m','' -replace '\x1b\]8;;[^\x07]*\x07','' }`,
+
+  __bar: `function __Bar($pct,$w=10,$wa=75,$ra=90){
+  $f=[Math]::Round(($pct/100)*$w); $e=$w-$f
+  $b=([string][char]0x2593)*[Math]::Max(0,$f)+([string][char]0x2591)*[Math]::Max(0,$e)
+  $c=if($pct -ge $ra){$R}elseif($pct -ge $wa){$Y}else{$G}
+  "$c$b$X"
+}`,
+
+  __resetTime: `function __ResetTime($epoch,$fmt='until'){
+  if(-not $epoch){return '?'}
+  $dt=[DateTimeOffset]::FromUnixTimeSeconds($epoch).LocalDateTime
+  $diff=[Math]::Max(0,($dt-(Get-Date)).TotalSeconds)
+  if($fmt -eq 'until'){$h=[int]($diff/3600);$m=[int](($diff%3600)/60);if($h -gt 0){"\${h}h \${m}m"}else{"\${m}m"}}
+  elseif($fmt -eq 'YYYY-MM-DD'){$dt.ToString('yyyy-MM-dd')}
+  elseif($fmt -eq 'DD/MM/YY'){$dt.ToString('dd/MM/yy')}
+  elseif($fmt -eq 'HH:mm'){$dt.ToString('HH:mm')}
+  else{[string]$epoch}
+}`,
+
+  __truncatePath: `function __TruncatePath($p,$max=40,$base=$false){
+  if(-not $p){return ''}
+  $s=if($base){Split-Path $p -Leaf}else{$p}
+  if($s.Length -le $max){$s}else{'…'+$s.Substring($s.Length-($max-1))}
+}`,
+
+  __duration: `function __Duration($ms=0){
+  $s=[int]($ms/1000); $m=[int]($s/60); $sc=$s%60
+  if($m -gt 0){"\${m}m \${sc}s"}else{"\${s}s"}
+}`,
+
+  __pack: `function __Pack($parts,$sep=' | ',$max=100,$hard=$false,$tol=10){
+  $ps=$parts|Where-Object{$_ -ne $null -and $_ -ne ''}
+  if(-not $ps){return ''}
+  $lim=if($hard){$max}else{$max*(1+$tol/100)}
+  $lines=@(@()); $run=0
+  foreach($p in $ps){
+    $l=(Strip-Ansi([string]$p)).Length; $add=$l+$(if($lines[-1].Count -gt 0){$sep.Length}else{0})
+    if($lines[-1].Count -gt 0 -and ($run+$add) -gt $lim){$lines+=,@($p);$run=$l}
+    else{$lines[-1]+=$p;$run+=$add}
+  }
+  ($lines|ForEach-Object{$_-join $sep})-join "\`n"
+}`,
+
+  __cacheGit: `function __CacheGit($sid,$ttl,$run){
+  $f="$env:TEMP\statusline-git-cache-$sid"
+  try{$c=Get-Content $f -Raw|ConvertFrom-Json;if(([DateTimeOffset]::UtcNow.ToUnixTimeSeconds()-$c.ts) -lt $ttl){return $c.d}}catch{}
+  $d=& $run
+  try{@{ts=[DateTimeOffset]::UtcNow.ToUnixTimeSeconds();d=$d}|ConvertTo-Json -Compress|Set-Content $f}catch{}
+  $d
+}`,
+
+  __git: `function __RunGit(){
+  try{
+    $branch=git rev-parse --abbrev-ref HEAD 2>$null
+    $staged=(git diff --cached --numstat 2>$null|Measure-Object -Line).Lines
+    $modified=(git diff --numstat 2>$null|Measure-Object -Line).Lines
+    $remote=git remote get-url origin 2>$null
+    @($branch,[int]$staged,[int]$modified,$remote)
+  }catch{@('?',0,0,'')}
+}`,
+};

--- a/src/codegen/runtimes/py.ts
+++ b/src/codegen/runtimes/py.ts
@@ -1,0 +1,19 @@
+export const PY_HELPERS: Record<string, string> = {
+  ANSI_COLORS: `G='\\x1b[32m'; Y='\\x1b[33m'; R='\\x1b[31m'; C='\\x1b[36m'; X='\\x1b[0m'`,
+
+  __stripAnsi: `import re as _re\ndef __strip_ansi(s):\n    s=_re.sub(r'\\x1b\\[[0-9;]*m','',str(s))\n    return _re.sub(r'\\x1b\\]8;;[^\\x07]*\\x07','',s)`,
+
+  __bar: `def __bar(pct,w=10,wa=75,ra=90):\n    f=round((pct/100)*w); b='\\u2593'*max(0,f)+'\\u2591'*max(0,w-f)\n    c=R if pct>=ra else Y if pct>=wa else G\n    return c+b+X`,
+
+  __resetTime: `def __reset_time(epoch,fmt='until'):\n    if not epoch: return '?'\n    from datetime import datetime,timezone\n    dt=datetime.fromtimestamp(epoch,tz=timezone.utc); now=datetime.now(tz=timezone.utc)\n    diff=max(0,(dt-now).total_seconds())\n    if fmt=='until':\n        h=int(diff//3600); m=int((diff%3600)//60)\n        return f'{h}h {m}m' if h>0 else f'{m}m'\n    if fmt=='YYYY-MM-DD': return dt.strftime('%Y-%m-%d')\n    if fmt=='DD/MM/YY': return dt.strftime('%d/%m/%y')\n    if fmt=='HH:mm': return dt.strftime('%H:%M')\n    return str(epoch)`,
+
+  __truncatePath: `def __truncate_path(p,max_len=40,base=False):\n    if not p: return ''\n    s=p.split('/')[-1] if base else p\n    return s if len(s)<=max_len else '\\u2026'+s[-(max_len-1):]`,
+
+  __duration: `def __duration(ms=0):\n    s=int(ms//1000); m=s//60; sc=s%60\n    return f'{m}m {sc}s' if m>0 else f'{sc}s'`,
+
+  __pack: `def __pack(parts,sep=' | ',max_len=100,hard=False,tol=10):\n    ps=[str(p) for p in parts if p is not None and p!='']\n    if not ps: return ''\n    lim=max_len if hard else max_len*(1+tol/100)\n    lines=[[]]; run=0\n    for p in ps:\n        l=len(__strip_ansi(p)); add=l+(len(sep) if lines[-1] else 0)\n        if lines[-1] and run+add>lim: lines.append([p]); run=l\n        else: lines[-1].append(p); run+=add\n    return '\\n'.join(sep.join(line) for line in lines)`,
+
+  __cacheGit: `def __cache_git(sid,ttl,run):\n    import os,json,time as _t\n    f=os.path.join(os.environ.get('TMPDIR','/tmp'),f'statusline-git-cache-{sid}')\n    try:\n        with open(f) as fp: c=json.load(fp)\n        if _t.time()-c['ts']<ttl: return c['d']\n    except Exception: pass\n    d=run()\n    try:\n        with open(f,'w') as fp: json.dump({'ts':_t.time(),'d':d},fp)\n    except Exception: pass\n    return d`,
+
+  __git: `def __run_git():\n    import subprocess\n    def e(cmd):\n        r=subprocess.run(cmd,shell=True,capture_output=True,text=True)\n        return r.stdout.strip()\n    try:\n        branch=e('git rev-parse --abbrev-ref HEAD') or '?'\n        staged=int(e('git diff --cached --numstat 2>/dev/null|wc -l') or '0')\n        modified=int(e('git diff --numstat 2>/dev/null|wc -l') or '0')\n        remote=e('git remote get-url origin 2>/dev/null')\n        return [branch,staged,modified,remote]\n    except Exception: return ['?',0,0,'']`,
+};

--- a/src/codegen/runtimes/sh.ts
+++ b/src/codegen/runtimes/sh.ts
@@ -1,0 +1,19 @@
+export const SH_HELPERS: Record<string, string> = {
+  ANSI_COLORS: `G=$'\\e[32m'; Y=$'\\e[33m'; R=$'\\e[31m'; C=$'\\e[36m'; X=$'\\e[0m'`,
+
+  __stripAnsi: `__strip_ansi() { echo "$1" | sed $'s/\\\\e\\\\[[0-9;]*m//g'; }`,
+
+  __bar: `__bar() {\n  local pct=$1 w=\${2:-10} wa=\${3:-75} ra=\${4:-90}\n  local f=$(( (pct * w + 50) / 100 )) e bar="" i\n  e=$(( w - f ))\n  for ((i=0;i<f;i++)); do bar+=$'\\u2593'; done\n  for ((i=0;i<e;i++)); do bar+=$'\\u2591'; done\n  local c\n  if [ "$pct" -ge "$ra" ]; then c=$R\n  elif [ "$pct" -ge "$wa" ]; then c=$Y\n  else c=$G; fi\n  printf "%s%s%s" "$c" "$bar" "$X"\n}`,
+
+  __resetTime: `__reset_time() {\n  local epoch=$1 fmt=\${2:-until}\n  local now; now=$(date +%s); local diff=$(( epoch - now ))\n  [ $diff -le 0 ] && echo "now" && return\n  if [ "$fmt" = "until" ]; then\n    local h=$(( diff/3600 )) m=$(( (diff%3600)/60 ))\n    [ $h -gt 0 ] && echo "\${h}h \${m}m" || echo "\${m}m"\n  elif [ "$fmt" = "YYYY-MM-DD" ]; then date -d "@$epoch" +%Y-%m-%d 2>/dev/null || date -r "$epoch" +%Y-%m-%d\n  elif [ "$fmt" = "DD/MM/YY" ]; then date -d "@$epoch" +%d/%m/%y 2>/dev/null || date -r "$epoch" +%d/%m/%y\n  elif [ "$fmt" = "HH:mm" ]; then date -d "@$epoch" +%H:%M 2>/dev/null || date -r "$epoch" +%H:%M\n  fi\n}`,
+
+  __truncatePath: `__truncate_path() {\n  local p=$1 max=\${2:-40} base=\${3:-0}\n  [ -z "$p" ] && echo "" && return\n  [ "$base" = "1" ] || [ "$base" = "true" ] && p=$(basename "$p")\n  if [ \${#p} -le $max ]; then echo "$p"\n  else echo "…\${p: -(max-1)}"; fi\n}`,
+
+  __duration: `__duration() {\n  local ms=\${1:-0} s m sc\n  s=$(( ms/1000 )); m=$(( s/60 )); sc=$(( s%60 ))\n  [ $m -gt 0 ] && echo "\${m}m \${sc}s" || echo "\${s}s"\n}`,
+
+  __pack: `__pack() {\n  local sep=$1 max=$2 hard=$3 tol=$4; shift 4\n  local lim result="" run=0\n  if [ "$hard" = "true" ]; then lim=$max\n  else lim=$(awk "BEGIN{printf \\"%d\\",$max*(1+$tol/100)}"); fi\n  for p in "$@"; do\n    [ -z "$p" ] && continue\n    local l; l=$(echo "$p"|__strip_ansi|wc -m)\n    local add=$l\n    [ -n "$result" ] && add=$(( add + \${#sep} ))\n    if [ -n "$result" ] && [ $(( run + add )) -gt $lim ]; then\n      result="$result\\n$p"; run=$l\n    else\n      result="\${result:+$result$sep}$p"; run=$(( run + add ))\n    fi\n  done\n  printf "%b\\n" "$result"\n}`,
+
+  __cacheGit: `__cache_git() {\n  local sid=$1 ttl=$2\n  local f="/tmp/statusline-git-cache-$sid"\n  local now; now=$(date +%s)\n  if [ -f "$f" ]; then\n    local ts; ts=$(head -1 "$f")\n    [ $(( now - ts )) -lt $ttl ] && tail -n +2 "$f" && return\n  fi\n  local r; r=$(__run_git)\n  { echo "$now"; echo "$r"; } > "$f"\n  echo "$r"\n}`,
+
+  __git: `__run_git() {\n  local branch staged modified remote\n  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || branch="?"\n  staged=$(git diff --cached --numstat 2>/dev/null|wc -l|tr -d ' ')\n  modified=$(git diff --numstat 2>/dev/null|wc -l|tr -d ' ')\n  remote=$(git remote get-url origin 2>/dev/null) || remote=""\n  printf "%s\\n%s\\n%s\\n%s" "$branch" "\${staged:-0}" "\${modified:-0}" "$remote"\n}`,
+};

--- a/src/schema/params/context.ts
+++ b/src/schema/params/context.ts
@@ -1,5 +1,15 @@
-import type { ParamDef, ResolvedOptions } from '../types';
-import { stubRender } from '../stubRender';
+import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import { RJ } from '../../codegen/renderJs';
+import { stubFragment } from '../stubRender';
+
+function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+  return {
+    js: jsFn,
+    py: () => stubFragment(id),
+    ps: () => stubFragment(id),
+    sh: () => stubFragment(id),
+  };
+}
 
 const w = (n: number) => () => n;
 const wBar = (defaultBarWidth: number) => (opts: ResolvedOptions) =>
@@ -8,28 +18,28 @@ const wBar = (defaultBarWidth: number) => (opts: ResolvedOptions) =>
 export const CONTEXT_PARAMS: ParamDef[] = [
   { id: 'ctx_used_pct', label: 'Context used %', group: 'context', emoji: '🧠',
     jsonPath: 'context_window.used_percentage', estimateWidth: w(8),
-    render: stubRender('ctx_used_pct') },
+    render: rw(RJ.ctxUsedPct, 'ctx_used_pct') },
   { id: 'ctx_remaining_pct', label: 'Context remaining %', group: 'context', emoji: '🧠',
     jsonPath: 'context_window.remaining_percentage', estimateWidth: w(8),
-    render: stubRender('ctx_remaining_pct') },
+    render: rw(RJ.ctxRemainingPct, 'ctx_remaining_pct') },
   { id: 'ctx_total_tokens', label: 'Total tokens (in+out)', group: 'context', emoji: '🧠',
-    estimateWidth: w(10), render: stubRender('ctx_total_tokens') },
+    estimateWidth: w(10), render: rw(RJ.ctxTotalTokens, 'ctx_total_tokens') },
   { id: 'ctx_window_size', label: 'Context window size', group: 'context',
-    estimateWidth: w(8), render: stubRender('ctx_window_size') },
+    estimateWidth: w(8), render: rw(RJ.ctxWindowSize, 'ctx_window_size') },
   { id: 'ctx_bar', label: 'Context usage bar', group: 'context', emoji: '🧠',
     subOptions: [{ kind: 'bar', defaultWidth: 10 },
                  { kind: 'colorize', defaultThresholds: [75, 90] }],
-    estimateWidth: wBar(10), render: stubRender('ctx_bar') },
+    estimateWidth: wBar(10), render: rw(RJ.ctxBar, 'ctx_bar') },
   { id: 'ctx_current_input', label: 'Current input tokens', group: 'context',
     jsonPath: 'context_window.current_usage.input_tokens', estimateWidth: w(8),
-    render: stubRender('ctx_current_input') },
+    render: rw(RJ.ctxCurrentInput, 'ctx_current_input') },
   { id: 'ctx_cache_read', label: 'Cache read tokens', group: 'context',
     jsonPath: 'context_window.current_usage.cache_read_input_tokens', estimateWidth: w(8),
-    render: stubRender('ctx_cache_read') },
+    render: rw(RJ.ctxCacheRead, 'ctx_cache_read') },
   { id: 'ctx_cache_creation', label: 'Cache creation tokens', group: 'context',
     jsonPath: 'context_window.current_usage.cache_creation_input_tokens', estimateWidth: w(8),
-    render: stubRender('ctx_cache_creation') },
+    render: rw(RJ.ctxCacheCreation, 'ctx_cache_creation') },
   { id: 'exceeds_200k', label: 'Exceeds 200k tokens flag', group: 'context',
     jsonPath: 'exceeds_200k_tokens', estimateWidth: w(6),
-    render: stubRender('exceeds_200k') },
+    render: rw(RJ.exceeds200k, 'exceeds_200k') },
 ];

--- a/src/schema/params/context.ts
+++ b/src/schema/params/context.ts
@@ -1,13 +1,16 @@
-import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import type { ParamDef, ResolvedOptions } from '../types';
 import { RJ } from '../../codegen/renderJs';
+import { RPY } from '../../codegen/renderPy';
+import { RSH } from '../../codegen/renderSh';
+import { RPS } from '../../codegen/renderPs';
 import { stubFragment } from '../stubRender';
 
-function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+function rw(key: string, id: string): import('../types').ParamDef['render'] {
   return {
-    js: jsFn,
-    py: () => stubFragment(id),
-    ps: () => stubFragment(id),
-    sh: () => stubFragment(id),
+    js: RJ[key] ?? (() => stubFragment(id)),
+    py: RPY[key] ?? (() => stubFragment(id)),
+    sh: RSH[key] ?? (() => stubFragment(id)),
+    ps: RPS[key] ?? (() => stubFragment(id)),
   };
 }
 
@@ -18,28 +21,28 @@ const wBar = (defaultBarWidth: number) => (opts: ResolvedOptions) =>
 export const CONTEXT_PARAMS: ParamDef[] = [
   { id: 'ctx_used_pct', label: 'Context used %', group: 'context', emoji: '🧠',
     jsonPath: 'context_window.used_percentage', estimateWidth: w(8),
-    render: rw(RJ.ctxUsedPct, 'ctx_used_pct') },
+    render: rw('ctxUsedPct', 'ctx_used_pct') },
   { id: 'ctx_remaining_pct', label: 'Context remaining %', group: 'context', emoji: '🧠',
     jsonPath: 'context_window.remaining_percentage', estimateWidth: w(8),
-    render: rw(RJ.ctxRemainingPct, 'ctx_remaining_pct') },
+    render: rw('ctxRemainingPct', 'ctx_remaining_pct') },
   { id: 'ctx_total_tokens', label: 'Total tokens (in+out)', group: 'context', emoji: '🧠',
-    estimateWidth: w(10), render: rw(RJ.ctxTotalTokens, 'ctx_total_tokens') },
+    estimateWidth: w(10), render: rw('ctxTotalTokens', 'ctx_total_tokens') },
   { id: 'ctx_window_size', label: 'Context window size', group: 'context',
-    estimateWidth: w(8), render: rw(RJ.ctxWindowSize, 'ctx_window_size') },
+    estimateWidth: w(8), render: rw('ctxWindowSize', 'ctx_window_size') },
   { id: 'ctx_bar', label: 'Context usage bar', group: 'context', emoji: '🧠',
     subOptions: [{ kind: 'bar', defaultWidth: 10 },
                  { kind: 'colorize', defaultThresholds: [75, 90] }],
-    estimateWidth: wBar(10), render: rw(RJ.ctxBar, 'ctx_bar') },
+    estimateWidth: wBar(10), render: rw('ctxBar', 'ctx_bar') },
   { id: 'ctx_current_input', label: 'Current input tokens', group: 'context',
     jsonPath: 'context_window.current_usage.input_tokens', estimateWidth: w(8),
-    render: rw(RJ.ctxCurrentInput, 'ctx_current_input') },
+    render: rw('ctxCurrentInput', 'ctx_current_input') },
   { id: 'ctx_cache_read', label: 'Cache read tokens', group: 'context',
     jsonPath: 'context_window.current_usage.cache_read_input_tokens', estimateWidth: w(8),
-    render: rw(RJ.ctxCacheRead, 'ctx_cache_read') },
+    render: rw('ctxCacheRead', 'ctx_cache_read') },
   { id: 'ctx_cache_creation', label: 'Cache creation tokens', group: 'context',
     jsonPath: 'context_window.current_usage.cache_creation_input_tokens', estimateWidth: w(8),
-    render: rw(RJ.ctxCacheCreation, 'ctx_cache_creation') },
+    render: rw('ctxCacheCreation', 'ctx_cache_creation') },
   { id: 'exceeds_200k', label: 'Exceeds 200k tokens flag', group: 'context',
     jsonPath: 'exceeds_200k_tokens', estimateWidth: w(6),
-    render: rw(RJ.exceeds200k, 'exceeds_200k') },
+    render: rw('exceeds200k', 'exceeds_200k') },
 ];

--- a/src/schema/params/cost.ts
+++ b/src/schema/params/cost.ts
@@ -1,18 +1,28 @@
-import type { ParamDef } from '../types';
-import { stubRender } from '../stubRender';
+import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import { RJ } from '../../codegen/renderJs';
+import { stubFragment } from '../stubRender';
+
+function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+  return {
+    js: jsFn,
+    py: () => stubFragment(id),
+    ps: () => stubFragment(id),
+    sh: () => stubFragment(id),
+  };
+}
 
 const w = (n: number) => () => n;
 
 export const COST_PARAMS: ParamDef[] = [
   { id: 'cost_total_usd', label: 'Total cost (USD)', group: 'cost', emoji: '💰',
     jsonPath: 'cost.total_cost_usd', estimateWidth: w(8),
-    render: stubRender('cost_total_usd') },
+    render: rw(RJ.costTotalUsd, 'cost_total_usd') },
   { id: 'cost_duration', label: 'Total duration', group: 'cost', emoji: '⏱️',
     jsonPath: 'cost.total_duration_ms', estimateWidth: w(8),
-    render: stubRender('cost_duration') },
+    render: rw(RJ.costDuration, 'cost_duration') },
   { id: 'cost_api_duration', label: 'API duration', group: 'cost', emoji: '⏱️',
     jsonPath: 'cost.total_api_duration_ms', estimateWidth: w(8),
-    render: stubRender('cost_api_duration') },
+    render: rw(RJ.costApiDuration, 'cost_api_duration') },
   { id: 'cost_lines', label: 'Lines added/removed', group: 'cost', emoji: '📝',
-    estimateWidth: w(12), render: stubRender('cost_lines') },
+    estimateWidth: w(12), render: rw(RJ.costLines, 'cost_lines') },
 ];

--- a/src/schema/params/cost.ts
+++ b/src/schema/params/cost.ts
@@ -1,13 +1,16 @@
-import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import type { ParamDef } from '../types';
 import { RJ } from '../../codegen/renderJs';
+import { RPY } from '../../codegen/renderPy';
+import { RSH } from '../../codegen/renderSh';
+import { RPS } from '../../codegen/renderPs';
 import { stubFragment } from '../stubRender';
 
-function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+function rw(key: string, id: string): import('../types').ParamDef['render'] {
   return {
-    js: jsFn,
-    py: () => stubFragment(id),
-    ps: () => stubFragment(id),
-    sh: () => stubFragment(id),
+    js: RJ[key] ?? (() => stubFragment(id)),
+    py: RPY[key] ?? (() => stubFragment(id)),
+    sh: RSH[key] ?? (() => stubFragment(id)),
+    ps: RPS[key] ?? (() => stubFragment(id)),
   };
 }
 
@@ -16,13 +19,13 @@ const w = (n: number) => () => n;
 export const COST_PARAMS: ParamDef[] = [
   { id: 'cost_total_usd', label: 'Total cost (USD)', group: 'cost', emoji: '💰',
     jsonPath: 'cost.total_cost_usd', estimateWidth: w(8),
-    render: rw(RJ.costTotalUsd, 'cost_total_usd') },
+    render: rw('costTotalUsd', 'cost_total_usd') },
   { id: 'cost_duration', label: 'Total duration', group: 'cost', emoji: '⏱️',
     jsonPath: 'cost.total_duration_ms', estimateWidth: w(8),
-    render: rw(RJ.costDuration, 'cost_duration') },
+    render: rw('costDuration', 'cost_duration') },
   { id: 'cost_api_duration', label: 'API duration', group: 'cost', emoji: '⏱️',
     jsonPath: 'cost.total_api_duration_ms', estimateWidth: w(8),
-    render: rw(RJ.costApiDuration, 'cost_api_duration') },
+    render: rw('costApiDuration', 'cost_api_duration') },
   { id: 'cost_lines', label: 'Lines added/removed', group: 'cost', emoji: '📝',
-    estimateWidth: w(12), render: rw(RJ.costLines, 'cost_lines') },
+    estimateWidth: w(12), render: rw('costLines', 'cost_lines') },
 ];

--- a/src/schema/params/git.ts
+++ b/src/schema/params/git.ts
@@ -1,13 +1,16 @@
-import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import type { ParamDef } from '../types';
 import { RJ } from '../../codegen/renderJs';
+import { RPY } from '../../codegen/renderPy';
+import { RSH } from '../../codegen/renderSh';
+import { RPS } from '../../codegen/renderPs';
 import { stubFragment } from '../stubRender';
 
-function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+function rw(key: string, id: string): import('../types').ParamDef['render'] {
   return {
-    js: jsFn,
-    py: () => stubFragment(id),
-    ps: () => stubFragment(id),
-    sh: () => stubFragment(id),
+    js: RJ[key] ?? (() => stubFragment(id)),
+    py: RPY[key] ?? (() => stubFragment(id)),
+    sh: RSH[key] ?? (() => stubFragment(id)),
+    ps: RPS[key] ?? (() => stubFragment(id)),
   };
 }
 
@@ -15,13 +18,13 @@ const w = (n: number) => () => n;
 
 export const GIT_PARAMS: ParamDef[] = [
   { id: 'git_branch', label: 'Git branch', group: 'git', emoji: '🌿',
-    estimateWidth: w(22), render: rw(RJ.gitBranch, 'git_branch') },
+    estimateWidth: w(22), render: rw('gitBranch', 'git_branch') },
   { id: 'git_staged_count', label: 'Git staged count', group: 'git',
     subOptions: [{ kind: 'colorize', defaultThresholds: [1, 1] }],
-    estimateWidth: w(4), render: rw(RJ.gitStagedCount, 'git_staged_count') },
+    estimateWidth: w(4), render: rw('gitStagedCount', 'git_staged_count') },
   { id: 'git_modified_count', label: 'Git modified count', group: 'git',
     subOptions: [{ kind: 'colorize', defaultThresholds: [1, 1] }],
-    estimateWidth: w(4), render: rw(RJ.gitModifiedCount, 'git_modified_count') },
+    estimateWidth: w(4), render: rw('gitModifiedCount', 'git_modified_count') },
   { id: 'git_remote_link', label: 'Git remote (clickable)', group: 'git', emoji: '🔗',
-    estimateWidth: w(24), render: rw(RJ.gitRemoteLink, 'git_remote_link') },
+    estimateWidth: w(24), render: rw('gitRemoteLink', 'git_remote_link') },
 ];

--- a/src/schema/params/git.ts
+++ b/src/schema/params/git.ts
@@ -1,17 +1,27 @@
-import type { ParamDef } from '../types';
-import { stubRender } from '../stubRender';
+import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import { RJ } from '../../codegen/renderJs';
+import { stubFragment } from '../stubRender';
+
+function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+  return {
+    js: jsFn,
+    py: () => stubFragment(id),
+    ps: () => stubFragment(id),
+    sh: () => stubFragment(id),
+  };
+}
 
 const w = (n: number) => () => n;
 
 export const GIT_PARAMS: ParamDef[] = [
   { id: 'git_branch', label: 'Git branch', group: 'git', emoji: '🌿',
-    estimateWidth: w(22), render: stubRender('git_branch') },
+    estimateWidth: w(22), render: rw(RJ.gitBranch, 'git_branch') },
   { id: 'git_staged_count', label: 'Git staged count', group: 'git',
     subOptions: [{ kind: 'colorize', defaultThresholds: [1, 1] }],
-    estimateWidth: w(4), render: stubRender('git_staged_count') },
+    estimateWidth: w(4), render: rw(RJ.gitStagedCount, 'git_staged_count') },
   { id: 'git_modified_count', label: 'Git modified count', group: 'git',
     subOptions: [{ kind: 'colorize', defaultThresholds: [1, 1] }],
-    estimateWidth: w(4), render: stubRender('git_modified_count') },
+    estimateWidth: w(4), render: rw(RJ.gitModifiedCount, 'git_modified_count') },
   { id: 'git_remote_link', label: 'Git remote (clickable)', group: 'git', emoji: '🔗',
-    estimateWidth: w(24), render: stubRender('git_remote_link') },
+    estimateWidth: w(24), render: rw(RJ.gitRemoteLink, 'git_remote_link') },
 ];

--- a/src/schema/params/identity.ts
+++ b/src/schema/params/identity.ts
@@ -1,5 +1,15 @@
-import type { ParamDef, ResolvedOptions } from '../types';
-import { stubRender } from '../stubRender';
+import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import { RJ } from '../../codegen/renderJs';
+import { stubFragment } from '../stubRender';
+
+function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+  return {
+    js: jsFn,
+    py: () => stubFragment(id),
+    ps: () => stubFragment(id),
+    sh: () => stubFragment(id),
+  };
+}
 
 const w = (n: number) => () => n;
 const wTruncate = (defaultMax: number) => (opts: ResolvedOptions) =>
@@ -7,23 +17,23 @@ const wTruncate = (defaultMax: number) => (opts: ResolvedOptions) =>
 
 export const IDENTITY_PARAMS: ParamDef[] = [
   { id: 'model_display', label: 'Model display name', group: 'identity',
-    jsonPath: 'model.display_name', estimateWidth: w(10), render: stubRender('model_display') },
+    jsonPath: 'model.display_name', estimateWidth: w(10), render: rw(RJ.modelDisplay, 'model_display') },
   { id: 'model_id', label: 'Model id', group: 'identity',
-    jsonPath: 'model.id', estimateWidth: w(20), render: stubRender('model_id') },
+    jsonPath: 'model.id', estimateWidth: w(20), render: rw(RJ.modelId, 'model_id') },
   { id: 'version', label: 'Claude Code version', group: 'identity',
-    jsonPath: 'version', estimateWidth: w(8), render: stubRender('version') },
+    jsonPath: 'version', estimateWidth: w(8), render: rw(RJ.version, 'version') },
   { id: 'output_style', label: 'Output style', group: 'identity',
-    jsonPath: 'output_style.name', estimateWidth: w(12), render: stubRender('output_style') },
+    jsonPath: 'output_style.name', estimateWidth: w(12), render: rw(RJ.outputStyle, 'output_style') },
   { id: 'effort', label: 'Reasoning effort', group: 'identity',
-    jsonPath: 'effort.level', estimateWidth: w(8), render: stubRender('effort') },
+    jsonPath: 'effort.level', estimateWidth: w(8), render: rw(RJ.effort, 'effort') },
   { id: 'thinking', label: 'Thinking enabled', group: 'identity', emoji: '💭',
-    jsonPath: 'thinking.enabled', estimateWidth: w(10), render: stubRender('thinking') },
+    jsonPath: 'thinking.enabled', estimateWidth: w(10), render: rw(RJ.thinking, 'thinking') },
   { id: 'vim', label: 'Vim mode', group: 'identity',
-    jsonPath: 'vim.mode', estimateWidth: w(11), render: stubRender('vim') },
+    jsonPath: 'vim.mode', estimateWidth: w(11), render: rw(RJ.vim, 'vim') },
   { id: 'agent', label: 'Agent name', group: 'identity', emoji: '🤖',
-    jsonPath: 'agent.name', estimateWidth: w(20), render: stubRender('agent') },
+    jsonPath: 'agent.name', estimateWidth: w(20), render: rw(RJ.agent, 'agent') },
   { id: 'session_name', label: 'Session name', group: 'identity',
     jsonPath: 'session_name',
     subOptions: [{ kind: 'truncate', defaultMaxChars: 24, basenameOnly: false }],
-    estimateWidth: wTruncate(24), render: stubRender('session_name') },
+    estimateWidth: wTruncate(24), render: rw(RJ.sessionName, 'session_name') },
 ];

--- a/src/schema/params/identity.ts
+++ b/src/schema/params/identity.ts
@@ -1,13 +1,16 @@
-import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import type { ParamDef, ResolvedOptions } from '../types';
 import { RJ } from '../../codegen/renderJs';
+import { RPY } from '../../codegen/renderPy';
+import { RSH } from '../../codegen/renderSh';
+import { RPS } from '../../codegen/renderPs';
 import { stubFragment } from '../stubRender';
 
-function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+function rw(key: string, id: string): import('../types').ParamDef['render'] {
   return {
-    js: jsFn,
-    py: () => stubFragment(id),
-    ps: () => stubFragment(id),
-    sh: () => stubFragment(id),
+    js: RJ[key] ?? (() => stubFragment(id)),
+    py: RPY[key] ?? (() => stubFragment(id)),
+    sh: RSH[key] ?? (() => stubFragment(id)),
+    ps: RPS[key] ?? (() => stubFragment(id)),
   };
 }
 
@@ -17,23 +20,23 @@ const wTruncate = (defaultMax: number) => (opts: ResolvedOptions) =>
 
 export const IDENTITY_PARAMS: ParamDef[] = [
   { id: 'model_display', label: 'Model display name', group: 'identity',
-    jsonPath: 'model.display_name', estimateWidth: w(10), render: rw(RJ.modelDisplay, 'model_display') },
+    jsonPath: 'model.display_name', estimateWidth: w(10), render: rw('modelDisplay', 'model_display') },
   { id: 'model_id', label: 'Model id', group: 'identity',
-    jsonPath: 'model.id', estimateWidth: w(20), render: rw(RJ.modelId, 'model_id') },
+    jsonPath: 'model.id', estimateWidth: w(20), render: rw('modelId', 'model_id') },
   { id: 'version', label: 'Claude Code version', group: 'identity',
-    jsonPath: 'version', estimateWidth: w(8), render: rw(RJ.version, 'version') },
+    jsonPath: 'version', estimateWidth: w(8), render: rw('version', 'version') },
   { id: 'output_style', label: 'Output style', group: 'identity',
-    jsonPath: 'output_style.name', estimateWidth: w(12), render: rw(RJ.outputStyle, 'output_style') },
+    jsonPath: 'output_style.name', estimateWidth: w(12), render: rw('outputStyle', 'output_style') },
   { id: 'effort', label: 'Reasoning effort', group: 'identity',
-    jsonPath: 'effort.level', estimateWidth: w(8), render: rw(RJ.effort, 'effort') },
+    jsonPath: 'effort.level', estimateWidth: w(8), render: rw('effort', 'effort') },
   { id: 'thinking', label: 'Thinking enabled', group: 'identity', emoji: '💭',
-    jsonPath: 'thinking.enabled', estimateWidth: w(10), render: rw(RJ.thinking, 'thinking') },
+    jsonPath: 'thinking.enabled', estimateWidth: w(10), render: rw('thinking', 'thinking') },
   { id: 'vim', label: 'Vim mode', group: 'identity',
-    jsonPath: 'vim.mode', estimateWidth: w(11), render: rw(RJ.vim, 'vim') },
+    jsonPath: 'vim.mode', estimateWidth: w(11), render: rw('vim', 'vim') },
   { id: 'agent', label: 'Agent name', group: 'identity', emoji: '🤖',
-    jsonPath: 'agent.name', estimateWidth: w(20), render: rw(RJ.agent, 'agent') },
+    jsonPath: 'agent.name', estimateWidth: w(20), render: rw('agent', 'agent') },
   { id: 'session_name', label: 'Session name', group: 'identity',
     jsonPath: 'session_name',
     subOptions: [{ kind: 'truncate', defaultMaxChars: 24, basenameOnly: false }],
-    estimateWidth: wTruncate(24), render: rw(RJ.sessionName, 'session_name') },
+    estimateWidth: wTruncate(24), render: rw('sessionName', 'session_name') },
 ];

--- a/src/schema/params/misc.ts
+++ b/src/schema/params/misc.ts
@@ -1,13 +1,16 @@
-import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import type { ParamDef, ResolvedOptions } from '../types';
 import { RJ } from '../../codegen/renderJs';
+import { RPY } from '../../codegen/renderPy';
+import { RSH } from '../../codegen/renderSh';
+import { RPS } from '../../codegen/renderPs';
 import { stubFragment } from '../stubRender';
 
-function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+function rw(key: string, id: string): import('../types').ParamDef['render'] {
   return {
-    js: jsFn,
-    py: () => stubFragment(id),
-    ps: () => stubFragment(id),
-    sh: () => stubFragment(id),
+    js: RJ[key] ?? (() => stubFragment(id)),
+    py: RPY[key] ?? (() => stubFragment(id)),
+    sh: RSH[key] ?? (() => stubFragment(id)),
+    ps: RPS[key] ?? (() => stubFragment(id)),
   };
 }
 
@@ -18,9 +21,9 @@ export const MISC_PARAMS: ParamDef[] = [
   { id: 'session_id', label: 'Session id', group: 'misc',
     jsonPath: 'session_id',
     subOptions: [{ kind: 'truncate', defaultMaxChars: 8, basenameOnly: false }],
-    estimateWidth: wTruncate(8), render: rw(RJ.sessionId, 'session_id') },
+    estimateWidth: wTruncate(8), render: rw('sessionId', 'session_id') },
   { id: 'transcript_path', label: 'Transcript path', group: 'misc',
     jsonPath: 'transcript_path',
     subOptions: [{ kind: 'truncate', defaultMaxChars: 30, basenameOnly: true }],
-    estimateWidth: wTruncate(30), render: rw(RJ.transcriptPath, 'transcript_path') },
+    estimateWidth: wTruncate(30), render: rw('transcriptPath', 'transcript_path') },
 ];

--- a/src/schema/params/misc.ts
+++ b/src/schema/params/misc.ts
@@ -1,5 +1,15 @@
-import type { ParamDef, ResolvedOptions } from '../types';
-import { stubRender } from '../stubRender';
+import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import { RJ } from '../../codegen/renderJs';
+import { stubFragment } from '../stubRender';
+
+function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+  return {
+    js: jsFn,
+    py: () => stubFragment(id),
+    ps: () => stubFragment(id),
+    sh: () => stubFragment(id),
+  };
+}
 
 const wTruncate = (defaultMax: number) => (opts: ResolvedOptions) =>
   (opts.sub.truncate?.maxChars ?? defaultMax) + 2;
@@ -8,9 +18,9 @@ export const MISC_PARAMS: ParamDef[] = [
   { id: 'session_id', label: 'Session id', group: 'misc',
     jsonPath: 'session_id',
     subOptions: [{ kind: 'truncate', defaultMaxChars: 8, basenameOnly: false }],
-    estimateWidth: wTruncate(8), render: stubRender('session_id') },
+    estimateWidth: wTruncate(8), render: rw(RJ.sessionId, 'session_id') },
   { id: 'transcript_path', label: 'Transcript path', group: 'misc',
     jsonPath: 'transcript_path',
     subOptions: [{ kind: 'truncate', defaultMaxChars: 30, basenameOnly: true }],
-    estimateWidth: wTruncate(30), render: stubRender('transcript_path') },
+    estimateWidth: wTruncate(30), render: rw(RJ.transcriptPath, 'transcript_path') },
 ];

--- a/src/schema/params/rateLimits.ts
+++ b/src/schema/params/rateLimits.ts
@@ -1,13 +1,16 @@
-import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import type { ParamDef, ResolvedOptions } from '../types';
 import { RJ } from '../../codegen/renderJs';
+import { RPY } from '../../codegen/renderPy';
+import { RSH } from '../../codegen/renderSh';
+import { RPS } from '../../codegen/renderPs';
 import { stubFragment } from '../stubRender';
 
-function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+function rw(key: string, id: string): import('../types').ParamDef['render'] {
   return {
-    js: jsFn,
-    py: () => stubFragment(id),
-    ps: () => stubFragment(id),
-    sh: () => stubFragment(id),
+    js: RJ[key] ?? (() => stubFragment(id)),
+    py: RPY[key] ?? (() => stubFragment(id)),
+    sh: RSH[key] ?? (() => stubFragment(id)),
+    ps: RPS[key] ?? (() => stubFragment(id)),
   };
 }
 
@@ -18,24 +21,24 @@ const wBar = (defaultBarWidth: number) => (opts: ResolvedOptions) =>
 export const RATE_LIMITS_PARAMS: ParamDef[] = [
   { id: 'rate_5h_pct', label: '5h limit %', group: 'rate_limits',
     jsonPath: 'rate_limits.five_hour.used_percentage',
-    estimateWidth: w(8), render: rw(RJ.rate5hPct, 'rate_5h_pct') },
+    estimateWidth: w(8), render: rw('rate5hPct', 'rate_5h_pct') },
   { id: 'rate_5h_bar', label: '5h limit bar', group: 'rate_limits',
     subOptions: [{ kind: 'bar', defaultWidth: 10 },
                  { kind: 'colorize', defaultThresholds: [75, 90] }],
-    estimateWidth: wBar(10), render: rw(RJ.rate5hBar, 'rate_5h_bar') },
+    estimateWidth: wBar(10), render: rw('rate5hBar', 'rate_5h_bar') },
   { id: 'rate_5h_resets', label: '5h reset time', group: 'rate_limits', emoji: '⏱️',
     subOptions: [{ kind: 'timestamp', default: 'until' }],
     jsonPath: 'rate_limits.five_hour.resets_at',
-    estimateWidth: w(12), render: rw(RJ.rate5hResets, 'rate_5h_resets') },
+    estimateWidth: w(12), render: rw('rate5hResets', 'rate_5h_resets') },
   { id: 'rate_7d_pct', label: '7d limit %', group: 'rate_limits',
     jsonPath: 'rate_limits.seven_day.used_percentage',
-    estimateWidth: w(8), render: rw(RJ.rate7dPct, 'rate_7d_pct') },
+    estimateWidth: w(8), render: rw('rate7dPct', 'rate_7d_pct') },
   { id: 'rate_7d_bar', label: '7d limit bar', group: 'rate_limits',
     subOptions: [{ kind: 'bar', defaultWidth: 10 },
                  { kind: 'colorize', defaultThresholds: [75, 90] }],
-    estimateWidth: wBar(10), render: rw(RJ.rate7dBar, 'rate_7d_bar') },
+    estimateWidth: wBar(10), render: rw('rate7dBar', 'rate_7d_bar') },
   { id: 'rate_7d_resets', label: '7d reset time', group: 'rate_limits', emoji: '⏱️',
     subOptions: [{ kind: 'timestamp', default: 'until' }],
     jsonPath: 'rate_limits.seven_day.resets_at',
-    estimateWidth: w(12), render: rw(RJ.rate7dResets, 'rate_7d_resets') },
+    estimateWidth: w(12), render: rw('rate7dResets', 'rate_7d_resets') },
 ];

--- a/src/schema/params/rateLimits.ts
+++ b/src/schema/params/rateLimits.ts
@@ -1,5 +1,15 @@
-import type { ParamDef, ResolvedOptions } from '../types';
-import { stubRender } from '../stubRender';
+import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import { RJ } from '../../codegen/renderJs';
+import { stubFragment } from '../stubRender';
+
+function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+  return {
+    js: jsFn,
+    py: () => stubFragment(id),
+    ps: () => stubFragment(id),
+    sh: () => stubFragment(id),
+  };
+}
 
 const w = (n: number) => () => n;
 const wBar = (defaultBarWidth: number) => (opts: ResolvedOptions) =>
@@ -8,24 +18,24 @@ const wBar = (defaultBarWidth: number) => (opts: ResolvedOptions) =>
 export const RATE_LIMITS_PARAMS: ParamDef[] = [
   { id: 'rate_5h_pct', label: '5h limit %', group: 'rate_limits',
     jsonPath: 'rate_limits.five_hour.used_percentage',
-    estimateWidth: w(8), render: stubRender('rate_5h_pct') },
+    estimateWidth: w(8), render: rw(RJ.rate5hPct, 'rate_5h_pct') },
   { id: 'rate_5h_bar', label: '5h limit bar', group: 'rate_limits',
     subOptions: [{ kind: 'bar', defaultWidth: 10 },
                  { kind: 'colorize', defaultThresholds: [75, 90] }],
-    estimateWidth: wBar(10), render: stubRender('rate_5h_bar') },
+    estimateWidth: wBar(10), render: rw(RJ.rate5hBar, 'rate_5h_bar') },
   { id: 'rate_5h_resets', label: '5h reset time', group: 'rate_limits', emoji: '⏱️',
     subOptions: [{ kind: 'timestamp', default: 'until' }],
     jsonPath: 'rate_limits.five_hour.resets_at',
-    estimateWidth: w(12), render: stubRender('rate_5h_resets') },
+    estimateWidth: w(12), render: rw(RJ.rate5hResets, 'rate_5h_resets') },
   { id: 'rate_7d_pct', label: '7d limit %', group: 'rate_limits',
     jsonPath: 'rate_limits.seven_day.used_percentage',
-    estimateWidth: w(8), render: stubRender('rate_7d_pct') },
+    estimateWidth: w(8), render: rw(RJ.rate7dPct, 'rate_7d_pct') },
   { id: 'rate_7d_bar', label: '7d limit bar', group: 'rate_limits',
     subOptions: [{ kind: 'bar', defaultWidth: 10 },
                  { kind: 'colorize', defaultThresholds: [75, 90] }],
-    estimateWidth: wBar(10), render: stubRender('rate_7d_bar') },
+    estimateWidth: wBar(10), render: rw(RJ.rate7dBar, 'rate_7d_bar') },
   { id: 'rate_7d_resets', label: '7d reset time', group: 'rate_limits', emoji: '⏱️',
     subOptions: [{ kind: 'timestamp', default: 'until' }],
     jsonPath: 'rate_limits.seven_day.resets_at',
-    estimateWidth: w(12), render: stubRender('rate_7d_resets') },
+    estimateWidth: w(12), render: rw(RJ.rate7dResets, 'rate_7d_resets') },
 ];

--- a/src/schema/params/workspace.ts
+++ b/src/schema/params/workspace.ts
@@ -1,5 +1,15 @@
-import type { ParamDef, ResolvedOptions } from '../types';
-import { stubRender } from '../stubRender';
+import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import { RJ } from '../../codegen/renderJs';
+import { stubFragment } from '../stubRender';
+
+function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+  return {
+    js: jsFn,
+    py: () => stubFragment(id),
+    ps: () => stubFragment(id),
+    sh: () => stubFragment(id),
+  };
+}
 
 const w = (n: number) => () => n;
 const wTruncate = (defaultMax: number) => (opts: ResolvedOptions) =>
@@ -9,23 +19,23 @@ export const WORKSPACE_PARAMS: ParamDef[] = [
   { id: 'cwd', label: 'Current directory', group: 'workspace', emoji: '📁',
     jsonPath: 'workspace.current_dir',
     subOptions: [{ kind: 'truncate', defaultMaxChars: 40, basenameOnly: true }],
-    estimateWidth: wTruncate(40), render: stubRender('cwd') },
+    estimateWidth: wTruncate(40), render: rw(RJ.cwd, 'cwd') },
   { id: 'workspace_project', label: 'Project directory', group: 'workspace', emoji: '📁',
     jsonPath: 'workspace.project_dir',
     subOptions: [{ kind: 'truncate', defaultMaxChars: 40, basenameOnly: true }],
-    estimateWidth: wTruncate(40), render: stubRender('workspace_project') },
+    estimateWidth: wTruncate(40), render: rw(RJ.workspaceProject, 'workspace_project') },
   { id: 'workspace_added_count', label: 'Added dirs count', group: 'workspace',
     jsonPath: 'workspace.added_dirs', estimateWidth: w(6),
-    render: stubRender('workspace_added_count') },
+    render: rw(RJ.workspaceAddedCount, 'workspace_added_count') },
   { id: 'workspace_git_worktree', label: 'Git worktree (workspace)', group: 'workspace',
     jsonPath: 'workspace.git_worktree', estimateWidth: w(20),
-    render: stubRender('workspace_git_worktree') },
+    render: rw(RJ.workspaceGitWorktree, 'workspace_git_worktree') },
   { id: 'worktree_name', label: 'Worktree name', group: 'workspace',
-    jsonPath: 'worktree.name', estimateWidth: w(20), render: stubRender('worktree_name') },
+    jsonPath: 'worktree.name', estimateWidth: w(20), render: rw(RJ.worktreeName, 'worktree_name') },
   { id: 'worktree_branch', label: 'Worktree branch', group: 'workspace', emoji: '🌿',
-    jsonPath: 'worktree.branch', estimateWidth: w(22), render: stubRender('worktree_branch') },
+    jsonPath: 'worktree.branch', estimateWidth: w(22), render: rw(RJ.worktreeBranch, 'worktree_branch') },
   { id: 'worktree_original_branch', label: 'Worktree original branch',
     group: 'workspace', emoji: '🌿',
     jsonPath: 'worktree.original_branch', estimateWidth: w(22),
-    render: stubRender('worktree_original_branch') },
+    render: rw(RJ.worktreeOriginalBranch, 'worktree_original_branch') },
 ];

--- a/src/schema/params/workspace.ts
+++ b/src/schema/params/workspace.ts
@@ -1,13 +1,16 @@
-import type { ParamDef, ResolvedOptions, CodeFragment } from '../types';
+import type { ParamDef, ResolvedOptions } from '../types';
 import { RJ } from '../../codegen/renderJs';
+import { RPY } from '../../codegen/renderPy';
+import { RSH } from '../../codegen/renderSh';
+import { RPS } from '../../codegen/renderPs';
 import { stubFragment } from '../stubRender';
 
-function rw(jsFn: (o: ResolvedOptions) => CodeFragment, id: string): import('../types').ParamDef['render'] {
+function rw(key: string, id: string): import('../types').ParamDef['render'] {
   return {
-    js: jsFn,
-    py: () => stubFragment(id),
-    ps: () => stubFragment(id),
-    sh: () => stubFragment(id),
+    js: RJ[key] ?? (() => stubFragment(id)),
+    py: RPY[key] ?? (() => stubFragment(id)),
+    sh: RSH[key] ?? (() => stubFragment(id)),
+    ps: RPS[key] ?? (() => stubFragment(id)),
   };
 }
 
@@ -19,23 +22,23 @@ export const WORKSPACE_PARAMS: ParamDef[] = [
   { id: 'cwd', label: 'Current directory', group: 'workspace', emoji: '📁',
     jsonPath: 'workspace.current_dir',
     subOptions: [{ kind: 'truncate', defaultMaxChars: 40, basenameOnly: true }],
-    estimateWidth: wTruncate(40), render: rw(RJ.cwd, 'cwd') },
+    estimateWidth: wTruncate(40), render: rw('cwd', 'cwd') },
   { id: 'workspace_project', label: 'Project directory', group: 'workspace', emoji: '📁',
     jsonPath: 'workspace.project_dir',
     subOptions: [{ kind: 'truncate', defaultMaxChars: 40, basenameOnly: true }],
-    estimateWidth: wTruncate(40), render: rw(RJ.workspaceProject, 'workspace_project') },
+    estimateWidth: wTruncate(40), render: rw('workspaceProject', 'workspace_project') },
   { id: 'workspace_added_count', label: 'Added dirs count', group: 'workspace',
     jsonPath: 'workspace.added_dirs', estimateWidth: w(6),
-    render: rw(RJ.workspaceAddedCount, 'workspace_added_count') },
+    render: rw('workspaceAddedCount', 'workspace_added_count') },
   { id: 'workspace_git_worktree', label: 'Git worktree (workspace)', group: 'workspace',
     jsonPath: 'workspace.git_worktree', estimateWidth: w(20),
-    render: rw(RJ.workspaceGitWorktree, 'workspace_git_worktree') },
+    render: rw('workspaceGitWorktree', 'workspace_git_worktree') },
   { id: 'worktree_name', label: 'Worktree name', group: 'workspace',
-    jsonPath: 'worktree.name', estimateWidth: w(20), render: rw(RJ.worktreeName, 'worktree_name') },
+    jsonPath: 'worktree.name', estimateWidth: w(20), render: rw('worktreeName', 'worktree_name') },
   { id: 'worktree_branch', label: 'Worktree branch', group: 'workspace', emoji: '🌿',
-    jsonPath: 'worktree.branch', estimateWidth: w(22), render: rw(RJ.worktreeBranch, 'worktree_branch') },
+    jsonPath: 'worktree.branch', estimateWidth: w(22), render: rw('worktreeBranch', 'worktree_branch') },
   { id: 'worktree_original_branch', label: 'Worktree original branch',
     group: 'workspace', emoji: '🌿',
     jsonPath: 'worktree.original_branch', estimateWidth: w(22),
-    render: rw(RJ.worktreeOriginalBranch, 'worktree_original_branch') },
+    render: rw('worktreeOriginalBranch', 'worktree_original_branch') },
 ];


### PR DESCRIPTION
## Summary

- Runtime helper bodies for all 4 languages in `src/codegen/runtimes/{js,py,sh,ps}.ts` — ANSI colors, bar, resetTime, truncatePath, duration, pack, cacheGit, git extraction
- `src/codegen/renderJs.ts` + `renderPy.ts` + `renderSh.ts` + `renderPs.ts` — real render functions for all 40 params in all 4 languages
- `src/codegen/emitJs.ts`, `emitPython.ts`, `emitBash.ts`, `emitPowershell.ts` — script emitter orchestrators
- `src/codegen/emitSettings.ts` — generates the `settings.json` snippet
- All param files wired to real renders (no more stubs)

33/33 tests passing, typecheck clean. Snapshot tests pin emitter output for all 4 languages.