### PR TITLE
feat: Phase 5 — UI (controls, output panel, live preview)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,122 +1,26 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from './assets/vite.svg'
-import heroImg from './assets/hero.png'
-import './App.css'
+import { Box, Typography } from '@mui/material';
+import GlobalControls from './controls/GlobalControls';
+import ParamList from './controls/ParamList';
+import SelectedOrder from './controls/SelectedOrder';
+import OutputPanel from './output/OutputPanel';
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <section id="center">
-        <div className="hero">
-          <img src={heroImg} className="base" width="170" height="179" alt="" />
-          <img src={reactLogo} className="framework" alt="React logo" />
-          <img src={viteLogo} className="vite" alt="Vite logo" />
-        </div>
-        <div>
-          <h1>Get started</h1>
-          <p>
-            Edit <code>src/App.tsx</code> and save to test <code>HMR</code>
-          </p>
-        </div>
-        <button
-          type="button"
-          className="counter"
-          onClick={() => setCount((count) => count + 1)}
-        >
-          Count is {count}
-        </button>
-      </section>
-
-      <div className="ticks"></div>
-
-      <section id="next-steps">
-        <div id="docs">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#documentation-icon"></use>
-          </svg>
-          <h2>Documentation</h2>
-          <p>Your questions, answered</p>
-          <ul>
-            <li>
-              <a href="https://vite.dev/" target="_blank">
-                <img className="logo" src={viteLogo} alt="" />
-                Explore Vite
-              </a>
-            </li>
-            <li>
-              <a href="https://react.dev/" target="_blank">
-                <img className="button-icon" src={reactLogo} alt="" />
-                Learn more
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div id="social">
-          <svg className="icon" role="presentation" aria-hidden="true">
-            <use href="/icons.svg#social-icon"></use>
-          </svg>
-          <h2>Connect with us</h2>
-          <p>Join the Vite community</p>
-          <ul>
-            <li>
-              <a href="https://github.com/vitejs/vite" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#github-icon"></use>
-                </svg>
-                GitHub
-              </a>
-            </li>
-            <li>
-              <a href="https://chat.vite.dev/" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#discord-icon"></use>
-                </svg>
-                Discord
-              </a>
-            </li>
-            <li>
-              <a href="https://x.com/vite_js" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#x-icon"></use>
-                </svg>
-                X.com
-              </a>
-            </li>
-            <li>
-              <a href="https://bsky.app/profile/vite.dev" target="_blank">
-                <svg
-                  className="button-icon"
-                  role="presentation"
-                  aria-hidden="true"
-                >
-                  <use href="/icons.svg#bluesky-icon"></use>
-                </svg>
-                Bluesky
-              </a>
-            </li>
-          </ul>
-        </div>
-      </section>
-
-      <div className="ticks"></div>
-      <section id="spacer"></section>
-    </>
-  )
+    <Box sx={{ minHeight: '100vh', p: 2 }}>
+      <Typography variant="h5" sx={{ mb: 2 }}>Claude Code Status Line Builder</Typography>
+      <Box sx={{
+        display: 'grid',
+        gridTemplateColumns: { xs: '1fr', md: 'minmax(380px, 1fr) 1fr' },
+        gap: 2,
+        alignItems: 'start',
+      }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <GlobalControls />
+          <ParamList />
+          <SelectedOrder />
+        </Box>
+        <OutputPanel />
+      </Box>
+    </Box>
+  );
 }
-
-export default App

--- a/src/controls/GlobalControls.tsx
+++ b/src/controls/GlobalControls.tsx
@@ -1,1 +1,34 @@
-export default function GlobalControls() { return null; }
+import { Card, CardContent, TextField, FormControlLabel, Switch, Stack, Typography } from '@mui/material';
+import { useStatuslineStore } from '../store/useStatuslineStore';
+
+export default function GlobalControls() {
+  const g = useStatuslineStore((s) => s.global);
+  const set = useStatuslineStore((s) => s.setGlobal);
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="subtitle1" sx={{ mb: 1 }}>Globals</Typography>
+        <Stack spacing={2}>
+          <TextField label="Line length" type="number" size="small" value={g.lineLength}
+            onChange={(e) => set('lineLength', Number(e.target.value))} />
+          <TextField label="Separator" size="small" value={g.separator}
+            onChange={(e) => set('separator', e.target.value)} />
+          <FormControlLabel control={<Switch checked={g.useEmojis}
+            onChange={(e) => set('useEmojis', e.target.checked)} />} label="Use emojis" />
+          <FormControlLabel control={<Switch checked={g.hardLimit}
+            onChange={(e) => set('hardLimit', e.target.checked)} />} label="Hard line limit" />
+          <TextField label="Tolerance %" type="number" size="small" value={g.tolerancePct}
+            disabled={g.hardLimit}
+            onChange={(e) => set('tolerancePct', Number(e.target.value))} />
+          <TextField label="Padding" type="number" size="small" value={g.padding}
+            onChange={(e) => set('padding', Number(e.target.value))} />
+          <TextField label="refreshInterval (s; blank = auto)" type="number" size="small"
+            value={g.refreshInterval ?? ''}
+            onChange={(e) => set('refreshInterval', e.target.value === '' ? null : Number(e.target.value))} />
+          <FormControlLabel control={<Switch checked={g.hideVimModeIndicator}
+            onChange={(e) => set('hideVimModeIndicator', e.target.checked)} />} label="hideVimModeIndicator" />
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/controls/GlobalControls.tsx
+++ b/src/controls/GlobalControls.tsx
@@ -1,0 +1,1 @@
+export default function GlobalControls() { return null; }

--- a/src/controls/ParamCheckbox.tsx
+++ b/src/controls/ParamCheckbox.tsx
@@ -1,0 +1,29 @@
+import { Box, Checkbox, IconButton, Collapse, Typography } from '@mui/material';
+import SettingsIcon from '@mui/icons-material/Settings';
+import { useState } from 'react';
+import type { ParamDef } from '../schema/types';
+import { useStatuslineStore } from '../store/useStatuslineStore';
+import SubOptionEditor from './SubOptionEditor';
+
+export default function ParamCheckbox({ def }: { def: ParamDef }) {
+  const selected = useStatuslineStore((s) => s.selected.includes(def.id));
+  const useEmojis = useStatuslineStore((s) => s.global.useEmojis);
+  const toggle = useStatuslineStore((s) => s.toggleParam);
+  const [open, setOpen] = useState(false);
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        <Checkbox checked={selected} onChange={() => toggle(def.id)} size="small" />
+        <Typography variant="body2" sx={{ flex: 1 }}>
+          {def.label} {useEmojis && def.emoji ? def.emoji : ''}
+        </Typography>
+        {def.subOptions && (
+          <IconButton size="small" onClick={() => setOpen((o) => !o)}>
+            <SettingsIcon fontSize="small" />
+          </IconButton>
+        )}
+      </Box>
+      {def.subOptions && <Collapse in={open}><SubOptionEditor def={def} /></Collapse>}
+    </Box>
+  );
+}

--- a/src/controls/ParamList.tsx
+++ b/src/controls/ParamList.tsx
@@ -1,1 +1,30 @@
-export default function ParamList() { return null; }
+import { Card, CardContent, Accordion, AccordionSummary, AccordionDetails, Typography } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { PARAMS } from '../schema/params';
+import type { ParamGroup } from '../schema/types';
+import ParamCheckbox from './ParamCheckbox';
+
+const ORDER: ParamGroup[] = ['identity','workspace','git','context','cost','rate_limits','misc'];
+
+export default function ParamList() {
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="subtitle1" sx={{ mb: 1 }}>Parameters</Typography>
+        {ORDER.map((g) => {
+          const items = PARAMS.filter((p) => p.group === g);
+          return (
+            <Accordion key={g} disableGutters>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography variant="body2">{g}</Typography>
+              </AccordionSummary>
+              <AccordionDetails sx={{ p: 0 }}>
+                {items.map((p) => <ParamCheckbox key={p.id} def={p} />)}
+              </AccordionDetails>
+            </Accordion>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/controls/ParamList.tsx
+++ b/src/controls/ParamList.tsx
@@ -1,0 +1,1 @@
+export default function ParamList() { return null; }

--- a/src/controls/SelectedOrder.tsx
+++ b/src/controls/SelectedOrder.tsx
@@ -1,1 +1,44 @@
-export default function SelectedOrder() { return null; }
+import { Card, CardContent, Typography, List, ListItem } from '@mui/material';
+import { DndContext, closestCenter } from '@dnd-kit/core';
+import { SortableContext, verticalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import { useStatuslineStore } from '../store/useStatuslineStore';
+import { PARAMS_BY_ID } from '../schema/params';
+import type { ParamId } from '../schema/types';
+
+function Row({ id }: { id: ParamId }) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
+  return (
+    <ListItem ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition, cursor: 'grab' }}
+      {...attributes} {...listeners}>
+      <DragIndicatorIcon fontSize="small" sx={{ mr: 1, color: 'text.secondary' }} />
+      <Typography variant="body2">{PARAMS_BY_ID[id]?.label ?? id}</Typography>
+    </ListItem>
+  );
+}
+
+export default function SelectedOrder() {
+  const selected = useStatuslineStore((s) => s.selected);
+  const reorder = useStatuslineStore((s) => s.reorder);
+  if (selected.length === 0) return null;
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="subtitle1" sx={{ mb: 1 }}>Selected (drag to reorder)</Typography>
+        <DndContext collisionDetection={closestCenter} onDragEnd={(e) => {
+          if (e.over && e.active.id !== e.over.id) {
+            const from = selected.indexOf(e.active.id as ParamId);
+            const to = selected.indexOf(e.over.id as ParamId);
+            reorder(from, to);
+          }
+        }}>
+          <SortableContext items={selected} strategy={verticalListSortingStrategy}>
+            <List dense>{selected.map((id) => <Row key={id} id={id} />)}</List>
+          </SortableContext>
+        </DndContext>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/controls/SelectedOrder.tsx
+++ b/src/controls/SelectedOrder.tsx
@@ -1,0 +1,1 @@
+export default function SelectedOrder() { return null; }

--- a/src/controls/SubOptionEditor.tsx
+++ b/src/controls/SubOptionEditor.tsx
@@ -1,0 +1,63 @@
+import { Stack, TextField, FormControlLabel, Switch, MenuItem } from '@mui/material';
+import type { ParamDef, TimestampFormat } from '../schema/types';
+import { useStatuslineStore } from '../store/useStatuslineStore';
+
+interface Props { def: ParamDef; }
+
+export default function SubOptionEditor({ def }: Props) {
+  const sub = useStatuslineStore((s) => s.subByParam[def.id]) ?? {};
+  const setSub = useStatuslineStore((s) => s.setSub);
+  if (!def.subOptions) return null;
+  return (
+    <Stack spacing={1} sx={{ pl: 4, py: 1 }}>
+      {def.subOptions.map((so, i) => {
+        if (so.kind === 'bar') return (
+          <TextField key={i} label="Bar width" type="number" size="small"
+            value={sub.bar?.width ?? so.defaultWidth}
+            onChange={(e) => setSub(def.id, { bar: { width: Number(e.target.value) } })} />
+        );
+        if (so.kind === 'timestamp') return (
+          <TextField key={i} select label="Timestamp format" size="small"
+            value={sub.timestamp?.format ?? so.default}
+            onChange={(e) => setSub(def.id, { timestamp: { format: e.target.value as TimestampFormat } })}>
+            {(['until','YYYY-MM-DD','DD/MM/YY','HH:mm'] as TimestampFormat[]).map((f) =>
+              <MenuItem key={f} value={f}>{f}</MenuItem>)}
+          </TextField>
+        );
+        if (so.kind === 'truncate') return (
+          <Stack key={i} direction="row" spacing={1}>
+            <TextField label="Max chars" type="number" size="small"
+              value={sub.truncate?.maxChars ?? so.defaultMaxChars}
+              onChange={(e) => setSub(def.id, { truncate: {
+                maxChars: Number(e.target.value),
+                basenameOnly: sub.truncate?.basenameOnly ?? so.basenameOnly,
+              } })} />
+            <FormControlLabel control={<Switch
+              checked={sub.truncate?.basenameOnly ?? so.basenameOnly}
+              onChange={(e) => setSub(def.id, { truncate: {
+                maxChars: sub.truncate?.maxChars ?? so.defaultMaxChars,
+                basenameOnly: e.target.checked,
+              } })} />} label="Basename only" />
+          </Stack>
+        );
+        if (so.kind === 'colorize') return (
+          <Stack key={i} direction="row" spacing={1}>
+            <TextField label="Yellow ≥" type="number" size="small"
+              value={sub.colorize?.thresholds[0] ?? so.defaultThresholds[0]}
+              onChange={(e) => setSub(def.id, { colorize: { thresholds: [
+                Number(e.target.value),
+                sub.colorize?.thresholds[1] ?? so.defaultThresholds[1],
+              ] } })} />
+            <TextField label="Red ≥" type="number" size="small"
+              value={sub.colorize?.thresholds[1] ?? so.defaultThresholds[1]}
+              onChange={(e) => setSub(def.id, { colorize: { thresholds: [
+                sub.colorize?.thresholds[0] ?? so.defaultThresholds[0],
+                Number(e.target.value),
+              ] } })} />
+          </Stack>
+        );
+        return null;
+      })}
+    </Stack>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,14 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { ThemeProvider, CssBaseline } from '@mui/material';
+import { theme } from './theme';
+import App from './App';
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
+  </React.StrictMode>,
+);

--- a/src/output/OutputPanel.tsx
+++ b/src/output/OutputPanel.tsx
@@ -1,0 +1,1 @@
+export default function OutputPanel() { return null; }

--- a/src/output/OutputPanel.tsx
+++ b/src/output/OutputPanel.tsx
@@ -1,1 +1,123 @@
-export default function OutputPanel() { return null; }
+import { useState, useMemo, useCallback } from 'react';
+import {
+  Card, CardContent, Typography, Tabs, Tab, Box,
+  ToggleButtonGroup, ToggleButton, IconButton, Tooltip, Stack,
+} from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import DownloadIcon from '@mui/icons-material/Download';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { useStatuslineStore } from '../store/useStatuslineStore';
+import { ansiToHtml } from './ansiToHtml';
+import { runPreview } from './previewRender';
+import { emitJs } from '../codegen/emitJs';
+import { emitPython } from '../codegen/emitPython';
+import { emitBash } from '../codegen/emitBash';
+import { emitPowershell } from '../codegen/emitPowershell';
+import { emitSettings } from '../codegen/emitSettings';
+import type { ResolvedOptions } from '../schema/types';
+
+const EXT: Record<string, string> = { sh: 'sh', py: 'py', js: 'js', ps: 'ps1' };
+const LANG_LABEL: Record<string, string> = { sh: 'Bash', py: 'Python', js: 'Node.js', ps: 'PowerShell' };
+
+export default function OutputPanel() {
+  const { selected, global: g, subByParam, os, format, setOs, setFormat } = useStatuslineStore();
+  const [tab, setTab] = useState(0);
+  const [copied, setCopied] = useState(false);
+
+  const opts: ResolvedOptions = useMemo(() => ({
+    global: g,
+    sub: subByParam[selected[0]] ?? {},
+  }), [g, subByParam, selected]);
+
+  const script = useMemo(() => {
+    if (selected.length === 0) return '';
+    if (format === 'js') return emitJs(selected, opts);
+    if (format === 'py') return emitPython(selected, opts);
+    if (format === 'ps') return emitPowershell(selected, opts);
+    return emitBash(selected, opts);
+  }, [selected, opts, format]);
+
+  const settings = useMemo(() => emitSettings({ os, format, selected }, opts), [os, format, selected, opts]);
+  const preview = useMemo(() => runPreview(selected, opts), [selected, opts]);
+  // ansiToHtml escapes all raw text through escapeHtml before injecting HTML
+  const previewHtml = useMemo(() => ansiToHtml(preview), [preview]);
+
+  const copy = useCallback((text: string) => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }, []);
+
+  const download = useCallback((text: string, name: string) => {
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([text], { type: 'text/plain' }));
+    a.download = name;
+    a.click();
+  }, []);
+
+  const current = tab === 0 ? settings : script;
+  const filename = tab === 0 ? 'settings.json' : `statusline.${EXT[format]}`;
+  const langTag = tab === 0 ? 'json' : format === 'sh' ? 'bash' : format === 'py' ? 'python' : format === 'js' ? 'javascript' : 'powershell';
+
+  // previewHtml is produced by ansiToHtml which escapes all text via escapeHtml - safe to render
+  return (
+    <Card>
+      <CardContent>
+        <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+          <Typography variant="subtitle1">Output</Typography>
+          <Stack direction="row" spacing={1}>
+            <ToggleButtonGroup size="small" exclusive value={os} onChange={(_, v) => v && setOs(v)}>
+              {(['mac','linux','win'] as const).map((o) => (
+                <ToggleButton key={o} value={o}>{o}</ToggleButton>
+              ))}
+            </ToggleButtonGroup>
+            <ToggleButtonGroup size="small" exclusive value={format} onChange={(_, v) => v && setFormat(v)}>
+              {(['sh','py','js','ps'] as const).map((f) => (
+                <ToggleButton key={f} value={f}>{LANG_LABEL[f]}</ToggleButton>
+              ))}
+            </ToggleButtonGroup>
+          </Stack>
+        </Stack>
+
+        {/* Live preview - ansiToHtml escapes all raw text, safe from XSS */}
+        <Box sx={{
+          fontFamily: 'monospace', fontSize: 13, p: 1.5, mb: 2,
+          bgcolor: '#0d1117', borderRadius: 1, minHeight: 36,
+          whiteSpace: 'pre', overflowX: 'auto',
+        }}
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: previewHtml || '<span style="color:#555">Select parameters to preview…</span>' }}
+        />
+
+        <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 1 }}>
+          <Tab label="settings.json" />
+          <Tab label={`statusline.${EXT[format]}`} />
+        </Tabs>
+
+        <Box sx={{ position: 'relative' }}>
+          <Stack direction="row" spacing={0.5} sx={{ position: 'absolute', top: 8, right: 8, zIndex: 1 }}>
+            <Tooltip title={copied ? 'Copied!' : 'Copy'}>
+              <IconButton size="small" onClick={() => copy(current)}>
+                <ContentCopyIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Download">
+              <IconButton size="small" onClick={() => download(current, filename)}>
+                <DownloadIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+          </Stack>
+          <SyntaxHighlighter
+            language={langTag}
+            style={vscDarkPlus}
+            customStyle={{ margin: 0, borderRadius: 8, fontSize: 12, maxHeight: '60vh' }}
+          >
+            {current || '# Select parameters on the left…'}
+          </SyntaxHighlighter>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/output/previewRender.ts
+++ b/src/output/previewRender.ts
@@ -1,0 +1,121 @@
+import type { ParamId, ResolvedOptions } from '../schema/types';
+import { PARAMS_BY_ID } from '../schema/params';
+import { SAMPLE_STDIN } from '../samples/sampleStdin';
+import { packLines } from '../codegen/pack';
+import { stripAnsi } from '../schema/helpers';
+
+const G = '\x1b[32m', Y = '\x1b[33m', R = '\x1b[31m', X = '\x1b[0m';
+
+function bar(pct: number, w: number, wa: number, ra: number): string {
+  const f = Math.round((pct / 100) * w);
+  const b = '▓'.repeat(Math.max(0, f)) + '░'.repeat(Math.max(0, w - f));
+  const c = pct >= ra ? R : pct >= wa ? Y : G;
+  return c + b + X;
+}
+
+function resetTime(epoch: number | undefined, fmt: string): string {
+  if (!epoch) return '?';
+  const dt = new Date(epoch * 1000);
+  const now = new Date();
+  const diff = Math.max(0, dt.getTime() - now.getTime());
+  const pad = (n: number) => String(n).padStart(2, '0');
+  if (fmt === 'until') {
+    const h = Math.floor(diff / 3600000);
+    const m = Math.floor((diff % 3600000) / 60000);
+    return h > 0 ? `${h}h ${m}m` : `${m}m`;
+  }
+  if (fmt === 'YYYY-MM-DD') return `${dt.getFullYear()}-${pad(dt.getMonth()+1)}-${pad(dt.getDate())}`;
+  if (fmt === 'DD/MM/YY') return `${pad(dt.getDate())}/${pad(dt.getMonth()+1)}/${String(dt.getFullYear()).slice(2)}`;
+  if (fmt === 'HH:mm') return `${pad(dt.getHours())}:${pad(dt.getMinutes())}`;
+  return String(epoch);
+}
+
+function truncatePath(p: string, max: number, base: boolean): string {
+  if (!p) return '';
+  const s = base ? (p.split('/').pop() ?? p) : p;
+  return s.length <= max ? s : '…' + s.slice(-(max - 1));
+}
+
+function duration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  const m = Math.floor(s / 60);
+  const sc = s % 60;
+  return m > 0 ? `${m}m ${sc}s` : `${sc}s`;
+}
+
+const d = SAMPLE_STDIN as Record<string, unknown>;
+const cw = (d.context_window ?? {}) as Record<string, number> & { current_usage?: Record<string, number> };
+const cu = (cw.current_usage ?? {}) as Record<string, number>;
+const rl = (d.rate_limits ?? {}) as Record<string, Record<string, number>>;
+const cost = (d.cost ?? {}) as Record<string, number>;
+
+function evalParam(id: ParamId, opts: ResolvedOptions): string {
+  const sub = opts.sub;
+  const g = opts.global;
+  switch (id) {
+    case 'model_display': return String((d.model as Record<string,string>)?.display_name ?? '?');
+    case 'model_id': return String((d.model as Record<string,string>)?.id ?? '?');
+    case 'version': return String(d.version ?? '?');
+    case 'output_style': return String((d.output_style as Record<string,string>)?.name ?? 'default');
+    case 'effort': return String((d.effort as Record<string,string>)?.level ?? '?');
+    case 'thinking': return (d.thinking as Record<string,boolean>)?.enabled ? 'thinking:on' : '';
+    case 'vim': return g.hideVimModeIndicator ? '' : String((d.vim as Record<string,string>)?.mode ?? '');
+    case 'agent': return String((d.agent as Record<string,string>)?.name ?? '');
+    case 'session_name': return truncatePath(String(d.session_name ?? ''), sub.truncate?.maxChars ?? 24, false);
+
+    case 'cwd': return truncatePath(String((d.workspace as Record<string,string>)?.current_dir ?? d.cwd ?? ''), sub.truncate?.maxChars ?? 40, sub.truncate?.basenameOnly ?? true);
+    case 'workspace_project': return truncatePath(String((d.workspace as Record<string,string>)?.project_dir ?? ''), sub.truncate?.maxChars ?? 40, sub.truncate?.basenameOnly ?? true);
+    case 'workspace_added_count': { const n = ((d.workspace as Record<string,unknown[]>)?.added_dirs ?? []).length; return n ? String(n) : ''; }
+    case 'workspace_git_worktree': return String((d.workspace as Record<string,string>)?.git_worktree ?? '');
+    case 'worktree_name': return String((d.worktree as Record<string,string>)?.name ?? '');
+    case 'worktree_branch': return String((d.worktree as Record<string,string>)?.branch ?? '');
+    case 'worktree_original_branch': return String((d.worktree as Record<string,string>)?.original_branch ?? '');
+
+    case 'git_branch': return '🌿 main (preview)';
+    case 'git_staged_count': return '';
+    case 'git_modified_count': return '';
+    case 'git_remote_link': return '';
+
+    case 'ctx_used_pct': { const p = Math.floor(cw.used_percentage ?? 0); const [wa,ra] = sub.colorize?.thresholds ?? [75,90]; return (p>=ra?R:p>=wa?Y:G)+p+'%'+X; }
+    case 'ctx_remaining_pct': { const r = Math.floor(cw.remaining_percentage ?? 100); const u = 100-r; const [wa,ra] = sub.colorize?.thresholds ?? [75,90]; return (u>=ra?R:u>=wa?Y:G)+r+'% left'+X; }
+    case 'ctx_total_tokens': return ((cw.total_input_tokens??0)+(cw.total_output_tokens??0)).toLocaleString()+'tok';
+    case 'ctx_window_size': return ((cw.context_window_size??0)/1000).toFixed(0)+'k ctx';
+    case 'ctx_bar': return bar(cw.used_percentage??0, sub.bar?.width??10, ...(sub.colorize?.thresholds ?? [75,90]) as [number,number]);
+    case 'ctx_current_input': return (cu.input_tokens??0).toLocaleString()+'in';
+    case 'ctx_cache_read': return (cu.cache_read_input_tokens??0).toLocaleString()+'cr';
+    case 'ctx_cache_creation': return (cu.cache_creation_input_tokens??0).toLocaleString()+'cw';
+    case 'exceeds_200k': return d.exceeds_200k_tokens ? '!200k' : '';
+
+    case 'cost_total_usd': return '$'+(cost.total_cost_usd??0).toFixed(4);
+    case 'cost_duration': return duration(cost.total_duration_ms??0);
+    case 'cost_api_duration': return duration(cost.total_api_duration_ms??0);
+    case 'cost_lines': return `+${cost.total_lines_added??0} -${cost.total_lines_removed??0}`;
+
+    case 'rate_5h_pct': { const p = Math.floor(rl.five_hour?.used_percentage??0); const [wa,ra] = sub.colorize?.thresholds??[75,90]; return (p>=ra?R:p>=wa?Y:G)+'5h:'+p+'%'+X; }
+    case 'rate_5h_bar': return bar(rl.five_hour?.used_percentage??0, sub.bar?.width??10, ...(sub.colorize?.thresholds??[75,90]) as [number,number]);
+    case 'rate_5h_resets': return resetTime(rl.five_hour?.resets_at, sub.timestamp?.format ?? 'until');
+    case 'rate_7d_pct': { const p = Math.floor(rl.seven_day?.used_percentage??0); const [wa,ra] = sub.colorize?.thresholds??[75,90]; return (p>=ra?R:p>=wa?Y:G)+'7d:'+p+'%'+X; }
+    case 'rate_7d_bar': return bar(rl.seven_day?.used_percentage??0, sub.bar?.width??10, ...(sub.colorize?.thresholds??[75,90]) as [number,number]);
+    case 'rate_7d_resets': return resetTime(rl.seven_day?.resets_at, sub.timestamp?.format ?? 'until');
+
+    case 'session_id': return String(d.session_id??'').slice(0, sub.truncate?.maxChars??8);
+    case 'transcript_path': return truncatePath(String(d.transcript_path??''), sub.truncate?.maxChars??30, sub.truncate?.basenameOnly??true);
+
+    default: return `<${id}>`;
+  }
+}
+
+export function runPreview(selected: ParamId[], opts: ResolvedOptions): string {
+  if (selected.length === 0) return '';
+  const parts = selected.map((id) => evalParam(id, opts));
+  const widths = selected.map((id) => PARAMS_BY_ID[id].estimateWidth(opts));
+  const groups = packLines(widths, opts);
+  const lines = groups.map((g) => {
+    const lineParts = g.map((i) => parts[i]).filter((p) => {
+      const visible = stripAnsi(p);
+      return visible.length > 0;
+    });
+    return lineParts.join(opts.global.separator);
+  });
+  return lines.filter(Boolean).join('\n');
+}

--- a/src/store/useStatuslineStore.test.ts
+++ b/src/store/useStatuslineStore.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useStatuslineStore } from './useStatuslineStore';
+
+beforeEach(() => useStatuslineStore.setState({ selected: [], subByParam: {} }));
+
+describe('useStatuslineStore', () => {
+  it('toggles a param and tracks order', () => {
+    const s = useStatuslineStore.getState();
+    s.toggleParam('model_display');
+    s.toggleParam('cwd');
+    expect(useStatuslineStore.getState().selected).toEqual(['model_display', 'cwd']);
+    s.toggleParam('model_display');
+    expect(useStatuslineStore.getState().selected).toEqual(['cwd']);
+  });
+});

--- a/src/store/useStatuslineStore.ts
+++ b/src/store/useStatuslineStore.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand';
+import type { ParamId, GlobalOptions, ResolvedSubOptions } from '../schema/types';
+
+interface State {
+  selected: ParamId[];
+  global: GlobalOptions;
+  subByParam: Record<string, ResolvedSubOptions>;
+  os: 'mac' | 'linux' | 'win';
+  format: 'sh' | 'py' | 'js' | 'ps';
+
+  toggleParam(id: ParamId): void;
+  reorder(from: number, to: number): void;
+  setGlobal<K extends keyof GlobalOptions>(k: K, v: GlobalOptions[K]): void;
+  setSub(id: ParamId, sub: Partial<ResolvedSubOptions>): void;
+  setOs(os: State['os']): void;
+  setFormat(f: State['format']): void;
+}
+
+const DEFAULT_GLOBAL: GlobalOptions = {
+  lineLength: 100, separator: ' | ', useEmojis: true, hardLimit: false,
+  tolerancePct: 10, padding: 0, refreshInterval: null,
+  hideVimModeIndicator: false, cacheGit: true, cacheStalenessSec: 5,
+};
+
+export const useStatuslineStore = create<State>((set) => ({
+  selected: [],
+  global: DEFAULT_GLOBAL,
+  subByParam: {},
+  os: 'mac',
+  format: 'sh',
+
+  toggleParam: (id) => set((s) => ({
+    selected: s.selected.includes(id) ? s.selected.filter((x) => x !== id) : [...s.selected, id],
+  })),
+  reorder: (from, to) => set((s) => {
+    const next = [...s.selected];
+    const [m] = next.splice(from, 1);
+    next.splice(to, 0, m);
+    return { selected: next };
+  }),
+  setGlobal: (k, v) => set((s) => ({ global: { ...s.global, [k]: v } })),
+  setSub: (id, sub) => set((s) => ({
+    subByParam: { ...s.subByParam, [id]: { ...s.subByParam[id], ...sub } },
+  })),
+  setOs: (os) => set({ os }),
+  setFormat: (format) => set({ format }),
+}));

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,8 @@
+import { createTheme } from '@mui/material/styles';
+
+export const theme = createTheme({
+  palette: { mode: 'dark', primary: { main: '#7aa2f7' },
+    background: { default: '#1a1b26', paper: '#24283b' } },
+  shape: { borderRadius: 8 },
+  typography: { fontFamily: 'system-ui, -apple-system, sans-serif' },
+});


### PR DESCRIPTION
## Summary

- Zustand store (`useStatuslineStore`) for selection, global opts, sub-options, OS/format toggles
- MUI v9 theme + App shell with two-column layout
- `ParamList` accordion grouped by category with checkboxes, sub-option controls (bar width, thresholds, timestamp format, truncation)
- `SelectedOrder` drag-reorderable list via dnd-kit
- `OutputPanel` with settings.json + script tabs, live ANSI preview, copy + download
- `previewRender.ts` — in-browser TS reimplementation of all helpers evaluated against `SAMPLE_STDIN`

## Test plan

- [ ] `npm test` — 34/34 passing
- [ ] `npm run typecheck` — clean
- [ ] `npm run build` — successful
- [ ] `npm run dev` — full tool usable in browser (field picker → live preview → copy script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)