### PR TITLE
fix: UI bugs, Python emitter correctness, CI integration tests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,16 +10,18 @@ export default function App() {
       <Typography variant="h5" sx={{ mb: 2 }}>Claude Code Status Line Builder</Typography>
       <Box sx={{
         display: 'grid',
-        gridTemplateColumns: { xs: '1fr', md: 'minmax(380px, 1fr) 1fr' },
+        gridTemplateColumns: { xs: '1fr', md: '2fr 3fr' },
         gap: 2,
         alignItems: 'start',
       }}>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
           <GlobalControls />
           <ParamList />
-          <SelectedOrder />
         </Box>
-        <OutputPanel />
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <SelectedOrder />
+          <OutputPanel />
+        </Box>
       </Box>
     </Box>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,11 +14,11 @@ export default function App() {
         gap: 2,
         alignItems: 'start',
       }}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
           <GlobalControls />
           <ParamList />
         </Box>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
           <SelectedOrder />
           <OutputPanel />
         </Box>

--- a/src/codegen/__snapshots__/emitJs.test.ts.snap
+++ b/src/codegen/__snapshots__/emitJs.test.ts.snap
@@ -11,7 +11,10 @@ process.stdin.on('end', () => {
     const __pack=(parts,sep=' | ',max=100,hard=false,tol=10)=>{const ps=parts.filter(x=>x!=null&&x!=='');if(!ps.length)return'';const lim=hard?max:max*(1+tol/100),lines=[[]];let run=0;for(const p of ps){const l=__stripAnsi(String(p)).length,add=l+(lines[lines.length-1].length?sep.length:0);if(lines[lines.length-1].length&&run+add>lim){lines.push([p]);run=l}else{lines[lines.length-1].push(p);run+=add}}return lines.map(l=>l.join(sep)).join('\\n')};
     const G='\\x1b[32m',Y='\\x1b[33m',R='\\x1b[31m',C='\\x1b[36m',X='\\x1b[0m';
     const __bar=(pct,w=10,wa=75,ra=90)=>{const f=Math.round((pct/100)*w),b='\\u2593'.repeat(Math.max(0,f))+'\\u2591'.repeat(Math.max(0,w-f)),c=pct>=ra?R:pct>=wa?Y:G;return c+b+X};
-    console.log(__pack([d.model?.display_name??'?', __bar(d.context_window?.used_percentage??0,10,75,90)], " | ", 100, false, 10));
+    console.log(__pack([
+      d.model?.display_name??'?',
+      __bar(d.context_window?.used_percentage??0,10,75,90),
+    ], " | ", 100, false, 10));
   } catch (_e) {
     console.log('[?]');
   }
@@ -32,7 +35,11 @@ process.stdin.on('end', () => {
     const __cacheGit=(sid,ttl,run)=>{const os=require('os'),fs=require('fs'),f=os.tmpdir()+'/statusline-git-cache-'+sid;try{const c=JSON.parse(fs.readFileSync(f,'utf8'));if(Date.now()-c.ts<ttl*1e3)return c.d}catch(e){}const d=run();try{fs.writeFileSync(f,JSON.stringify({ts:Date.now(),d}))}catch(e){}return d};
     const G='\\x1b[32m',Y='\\x1b[33m',R='\\x1b[31m',C='\\x1b[36m',X='\\x1b[0m';
     const __GIT = __cacheGit(d.session_id ?? 'default', 5, __runGit);
-    console.log(__pack([d.model?.display_name??'?', __GIT[0], (__GIT[2]>0?(__GIT[2]>=1?R:__GIT[2]>=1?Y:G)+'M:'+__GIT[2]+X:'')], " | ", 100, false, 10));
+    console.log(__pack([
+      d.model?.display_name??'?',
+      __GIT[0],
+      (__GIT[2]>0?(__GIT[2]>=1?R:__GIT[2]>=1?Y:G)+'M:'+__GIT[2]+X:''),
+    ], " | ", 100, false, 10));
   } catch (_e) {
     console.log('[?]');
   }
@@ -50,7 +57,9 @@ process.stdin.on('end', () => {
     const __stripAnsi=(s)=>String(s).replace(/\\x1b\\[[0-9;]*m/g,'').replace(/\\x1b\\]8;;[^\\x07]*\\x07/g,'');
     const __pack=(parts,sep=' | ',max=100,hard=false,tol=10)=>{const ps=parts.filter(x=>x!=null&&x!=='');if(!ps.length)return'';const lim=hard?max:max*(1+tol/100),lines=[[]];let run=0;for(const p of ps){const l=__stripAnsi(String(p)).length,add=l+(lines[lines.length-1].length?sep.length:0);if(lines[lines.length-1].length&&run+add>lim){lines.push([p]);run=l}else{lines[lines.length-1].push(p);run+=add}}return lines.map(l=>l.join(sep)).join('\\n')};
     const __resetTime=(epoch,fmt='until')=>{if(!epoch)return'?';const dt=new Date(epoch*1e3),now=new Date(),diff=Math.max(0,dt-now),pad=n=>String(n).padStart(2,'0');if(fmt==='until'){const h=Math.floor(diff/36e5),m=Math.floor((diff%36e5)/6e4);return h>0?h+'h '+m+'m':m+'m'}if(fmt==='YYYY-MM-DD')return dt.getFullYear()+'-'+pad(dt.getMonth()+1)+'-'+pad(dt.getDate());if(fmt==='DD/MM/YY')return pad(dt.getDate())+'/'+pad(dt.getMonth()+1)+'/'+String(dt.getFullYear()).slice(2);if(fmt==='HH:mm')return pad(dt.getHours())+':'+pad(dt.getMinutes());return String(epoch)};
-    console.log(__pack([__resetTime(d.rate_limits?.five_hour?.resets_at,"until")], " | ", 100, false, 10));
+    console.log(__pack([
+      __resetTime(d.rate_limits?.five_hour?.resets_at,"until"),
+    ], " | ", 100, false, 10));
   } catch (_e) {
     console.log('[?]');
   }
@@ -68,7 +77,10 @@ process.stdin.on('end', () => {
     const __stripAnsi=(s)=>String(s).replace(/\\x1b\\[[0-9;]*m/g,'').replace(/\\x1b\\]8;;[^\\x07]*\\x07/g,'');
     const __pack=(parts,sep=' | ',max=100,hard=false,tol=10)=>{const ps=parts.filter(x=>x!=null&&x!=='');if(!ps.length)return'';const lim=hard?max:max*(1+tol/100),lines=[[]];let run=0;for(const p of ps){const l=__stripAnsi(String(p)).length,add=l+(lines[lines.length-1].length?sep.length:0);if(lines[lines.length-1].length&&run+add>lim){lines.push([p]);run=l}else{lines[lines.length-1].push(p);run+=add}}return lines.map(l=>l.join(sep)).join('\\n')};
     const __truncatePath=(p,max=40,base=false)=>{if(!p)return'';const s=base?(String(p).split('/').pop()||p):String(p);return s.length<=max?s:'\\u2026'+s.slice(-(max-1))};
-    console.log(__pack([d.model?.display_name??'?', __truncatePath(d.workspace?.current_dir??d.cwd??'',40,true)], " | ", 100, false, 10));
+    console.log(__pack([
+      d.model?.display_name??'?',
+      __truncatePath(d.workspace?.current_dir??d.cwd??'',40,true),
+    ], " | ", 100, false, 10));
   } catch (_e) {
     console.log('[?]');
   }

--- a/src/codegen/__snapshots__/emitPowershell.test.ts.snap
+++ b/src/codegen/__snapshots__/emitPowershell.test.ts.snap
@@ -4,7 +4,7 @@ exports[`emitPowershell > basic selection snapshot 1`] = `
 "$ErrorActionPreference = 'Continue'
 try {
     $d = $input | Out-String | ConvertFrom-Json
-
+function Strip-Ansi($s){ $s -replace '[[0-9;]*m','' -replace ']8;;[^]*','' }
 function __Pack($parts,$sep=' | ',$max=100,$hard=$false,$tol=10){
   $ps=$parts|Where-Object{$_ -ne $null -and $_ -ne ''}
   if(-not $ps){return ''}

--- a/src/codegen/__snapshots__/emitPython.test.ts.snap
+++ b/src/codegen/__snapshots__/emitPython.test.ts.snap
@@ -3,9 +3,7 @@
 exports[`emitPython > basic selection snapshot 1`] = `
 "#!/usr/bin/env python3
 import json, sys
-def main():
-    try:
-        d = json.load(sys.stdin)
+
 import re as _re
 def __strip_ansi(s):
     s=_re.sub(r'\\x1b\\[[0-9;]*m','',str(s))
@@ -29,7 +27,15 @@ def __bar(pct,w=10,wa=75,ra=90):
     f=round((pct/100)*w); b='\\u2593'*max(0,f)+'\\u2591'*max(0,w-f)
     c=R if pct>=ra else Y if pct>=wa else G
     return c+b+X
-    print(__pack([(d.get('model') or {}).get('display_name','?'), __truncate_path((d.get('workspace') or {}).get('current_dir','') or d.get('cwd',''),40,True), __bar((d.get('context_window') or {}).get('used_percentage',0),10,75,90)], " | ", 100, False, 10))
+
+def main():
+    try:
+        d = json.load(sys.stdin)
+        print(__pack([
+            (d.get('model') or {}).get('display_name','?'),
+            __truncate_path((d.get('workspace') or {}).get('current_dir','') or d.get('cwd',''),40,True),
+            __bar((d.get('context_window') or {}).get('used_percentage',0),10,75,90),
+        ], " | ", 100, False, 10))
     except Exception:
         print('[?]')
 
@@ -41,9 +47,7 @@ if __name__ == '__main__':
 exports[`emitPython > git extraction block 1`] = `
 "#!/usr/bin/env python3
 import json, sys
-def main():
-    try:
-        d = json.load(sys.stdin)
+
 import re as _re
 def __strip_ansi(s):
     s=_re.sub(r'\\x1b\\[[0-9;]*m','',str(s))
@@ -82,8 +86,15 @@ def __cache_git(sid,ttl,run):
         with open(f,'w') as fp: json.dump({'ts':_t.time(),'d':d},fp)
     except Exception: pass
     return d
-    __GIT = __cache_git(d.get('session_id','default'), 5, __run_git)
-    print(__pack([(d.get('model') or {}).get('display_name','?'), __GIT[0]], " | ", 100, False, 10))
+
+def main():
+    try:
+        d = json.load(sys.stdin)
+        __GIT = __cache_git(d.get('session_id','default'), 5, __run_git)
+        print(__pack([
+            (d.get('model') or {}).get('display_name','?'),
+            __GIT[0],
+        ], " | ", 100, False, 10))
     except Exception:
         print('[?]')
 

--- a/src/codegen/emit.integration.test.ts
+++ b/src/codegen/emit.integration.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SAMPLE_STDIN } from '../samples/sampleStdin';
+import { emitJs } from './emitJs';
+import { emitPython } from './emitPython';
+import { emitBash } from './emitBash';
+import type { ParamId, ResolvedOptions } from '../schema/types';
+
+const STDIN = JSON.stringify(SAMPLE_STDIN);
+
+const opts = (): ResolvedOptions => ({
+  global: {
+    lineLength: 100, separator: ' | ', useEmojis: false, hardLimit: false,
+    tolerancePct: 10, padding: 0, refreshInterval: null,
+    hideVimModeIndicator: false, cacheGit: false, cacheStalenessSec: 5,
+  },
+  sub: {},
+});
+
+const PARAMS: ParamId[] = ['model_display', 'version', 'effort'];
+
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[0-9;]*m/g, '').replace(/\x1b\]8;;[^\x07]*\x07/g, '');
+}
+
+function runScript(cmd: string, args: string[], script: string): string {
+  const ext = cmd === 'node' ? 'js' : cmd === 'python3' || cmd === 'python' ? 'py' : 'sh';
+  const file = join(tmpdir(), `sl-test-${Date.now()}.${ext}`);
+  writeFileSync(file, script, { mode: 0o755 });
+  try {
+    const result = spawnSync(cmd, [...args, file], {
+      input: STDIN,
+      encoding: 'utf-8',
+      timeout: 10000,
+    });
+    if (result.error) throw result.error;
+    return result.stdout ?? '';
+  } finally {
+    try { unlinkSync(file); } catch { /* ignore */ }
+  }
+}
+
+describe('JS emitter integration', () => {
+  it('outputs model_display, version, effort from SAMPLE_STDIN', () => {
+    const script = emitJs(PARAMS, opts());
+    const out = stripAnsi(runScript('node', [], script));
+    expect(out).toContain(SAMPLE_STDIN.model.display_name);
+    expect(out).toContain(SAMPLE_STDIN.version);
+    expect(out).toContain(SAMPLE_STDIN.effort.level);
+  });
+
+  it('outputs ctx_used_pct percentage', () => {
+    const script = emitJs(['ctx_used_pct'], opts());
+    const out = stripAnsi(runScript('node', [], script));
+    expect(out).toContain(`${SAMPLE_STDIN.context_window.used_percentage}%`);
+  });
+
+  it('outputs session_id truncated to 8 chars', () => {
+    const script = emitJs(['session_id'], opts());
+    const out = stripAnsi(runScript('node', [], script));
+    expect(out).toContain(SAMPLE_STDIN.session_id.slice(0, 8));
+  });
+});
+
+describe('Python emitter integration', () => {
+  const py = spawnSync('python3', ['--version'], { encoding: 'utf-8' });
+  const hasPy = py.status === 0;
+  const itPy = hasPy ? it : it.skip;
+
+  itPy('outputs model_display, version, effort from SAMPLE_STDIN', () => {
+    const script = emitPython(PARAMS, opts());
+    const out = stripAnsi(runScript('python3', [], script));
+    expect(out).toContain(SAMPLE_STDIN.model.display_name);
+    expect(out).toContain(SAMPLE_STDIN.version);
+    expect(out).toContain(SAMPLE_STDIN.effort.level);
+  });
+
+  itPy('outputs ctx_used_pct percentage', () => {
+    const script = emitPython(['ctx_used_pct'], opts());
+    const out = stripAnsi(runScript('python3', [], script));
+    expect(out).toContain(`${SAMPLE_STDIN.context_window.used_percentage}%`);
+  });
+
+  itPy('outputs session_id truncated to 8 chars', () => {
+    const script = emitPython(['session_id'], opts());
+    const out = stripAnsi(runScript('python3', [], script));
+    expect(out).toContain(SAMPLE_STDIN.session_id.slice(0, 8));
+  });
+});
+
+describe('Bash emitter integration', () => {
+  const isUnix = process.platform !== 'win32';
+  const jqCheck = isUnix ? spawnSync('jq', ['--version'], { encoding: 'utf-8' }) : { status: 1 };
+  const hasBash = isUnix && jqCheck.status === 0;
+  const itBash = hasBash ? it : it.skip;
+
+  itBash('outputs model_display, version, effort from SAMPLE_STDIN', () => {
+    const script = emitBash(PARAMS, opts());
+    const out = stripAnsi(runScript('bash', [], script));
+    expect(out).toContain(SAMPLE_STDIN.model.display_name);
+    expect(out).toContain(SAMPLE_STDIN.version);
+    expect(out).toContain(SAMPLE_STDIN.effort.level);
+  });
+
+  itBash('outputs ctx_used_pct percentage', () => {
+    const script = emitBash(['ctx_used_pct'], opts());
+    const out = stripAnsi(runScript('bash', [], script));
+    expect(out).toContain(`${SAMPLE_STDIN.context_window.used_percentage}%`);
+  });
+});

--- a/src/codegen/emitJs.ts
+++ b/src/codegen/emitJs.ts
@@ -23,8 +23,8 @@ export function emitJs(selected: ParamId[], opts: ResolvedOptions): string {
 
   const linesCode = lineGroups
     .map((g) => {
-      const parts = g.map((idx) => fragments[idx].expr).join(', ');
-      return `    console.log(__pack([${parts}], ${JSON.stringify(opts.global.separator)}, ${opts.global.lineLength}, ${opts.global.hardLimit}, ${opts.global.tolerancePct}));`;
+      const inner = g.map((idx) => '      ' + fragments[idx].expr).join(',\n');
+      return `    console.log(__pack([\n${inner},\n    ], ${JSON.stringify(opts.global.separator)}, ${opts.global.lineLength}, ${opts.global.hardLimit}, ${opts.global.tolerancePct}));`;
     })
     .join('\n');
 

--- a/src/codegen/emitPowershell.ts
+++ b/src/codegen/emitPowershell.ts
@@ -9,7 +9,7 @@ export function emitPowershell(selected: ParamId[], opts: ResolvedOptions): stri
   const widths = selected.map((id) => PARAMS_BY_ID[id].estimateWidth(opts));
   const lineGroups = packLines(widths, opts);
   const rawHelpers = collectHelpers(fragments);
-  const helperIds = ['Strip-Ansi', '__pack', ...rawHelpers].filter(
+  const helperIds = ['__stripAnsi', '__pack', ...rawHelpers].filter(
     (h, i, a) => a.indexOf(h) === i,
   );
   const helperBlock = helperIds.map((h) => PS_HELPERS[h] ?? '').join('\n');

--- a/src/codegen/emitPython.ts
+++ b/src/codegen/emitPython.ts
@@ -17,23 +17,25 @@ export function emitPython(selected: ParamId[], opts: ResolvedOptions): string {
   const needsGit = rawHelpers.includes('__git');
   const gitBlock = needsGit
     ? opts.global.cacheGit
-      ? `    __GIT = __cache_git(d.get('session_id','default'), ${opts.global.cacheStalenessSec}, __run_git)\n`
-      : `    __GIT = __run_git()\n`
+      ? `        __GIT = __cache_git(d.get('session_id','default'), ${opts.global.cacheStalenessSec}, __run_git)\n`
+      : `        __GIT = __run_git()\n`
     : '';
 
   const lines = lineGroups
     .map((g) => {
-      const parts = g.map((idx) => fragments[idx].expr).join(', ');
-      return `    print(__pack([${parts}], ${JSON.stringify(opts.global.separator)}, ${opts.global.lineLength}, ${opts.global.hardLimit ? 'True' : 'False'}, ${opts.global.tolerancePct}))`;
+      const inner = g.map((idx) => '            ' + fragments[idx].expr).join(',\n');
+      return `        print(__pack([\n${inner},\n        ], ${JSON.stringify(opts.global.separator)}, ${opts.global.lineLength}, ${opts.global.hardLimit ? 'True' : 'False'}, ${opts.global.tolerancePct}))`;
     })
     .join('\n');
 
   return `#!/usr/bin/env python3
 import json, sys
+
+${helperBlock}
+
 def main():
     try:
         d = json.load(sys.stdin)
-${helperBlock}
 ${gitBlock}${lines}
     except Exception:
         print('[?]')

--- a/src/codegen/emitSettings.ts
+++ b/src/codegen/emitSettings.ts
@@ -24,7 +24,7 @@ function commandFor(os: EmitOs, fmt: EmitFmt): string {
   if (fmt === 'sh') return '~/.claude/statusline.sh';
   if (fmt === 'py') return '~/.claude/statusline.py';
   if (fmt === 'js') return '~/.claude/statusline.js';
-  throw new Error(`Unsupported os/format: ${os}/${fmt}`);
+  return '~/.claude/statusline.sh';
 }
 
 export function emitSettings(input: EmitSettingsInput, opts: ResolvedOptions): string {

--- a/src/codegen/renderPy.ts
+++ b/src/codegen/renderPy.ts
@@ -45,14 +45,14 @@ export const RPY: Record<string, RenderFn> = {
     const [wa, ra] = opts.sub.colorize?.thresholds ?? [1, 1];
     return f(
       opts.global.cacheGit ? ['ANSI_COLORS', '__git', '__cacheGit'] : ['ANSI_COLORS', '__git'],
-      `(f'{{R if __GIT[1]>=${ra} else Y if __GIT[1]>=${wa} else G}}S:{{__GIT[1]}}{{X}}' if __GIT[1]>0 else '')`,
+      `(f'{R if __GIT[1]>=${ra} else Y if __GIT[1]>=${wa} else G}S:{__GIT[1]}{X}' if __GIT[1]>0 else '')`,
     );
   },
   gitModifiedCount: (opts) => {
     const [wa, ra] = opts.sub.colorize?.thresholds ?? [1, 1];
     return f(
       opts.global.cacheGit ? ['ANSI_COLORS', '__git', '__cacheGit'] : ['ANSI_COLORS', '__git'],
-      `(f'{{R if __GIT[2]>=${ra} else Y if __GIT[2]>=${wa} else G}}M:{{__GIT[2]}}{{X}}' if __GIT[2]>0 else '')`,
+      `(f'{R if __GIT[2]>=${ra} else Y if __GIT[2]>=${wa} else G}M:{__GIT[2]}{X}' if __GIT[2]>0 else '')`,
     );
   },
   gitRemoteLink: (opts) => f(
@@ -63,11 +63,11 @@ export const RPY: Record<string, RenderFn> = {
   // context
   ctxUsedPct: (opts) => {
     const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
-    return f(['ANSI_COLORS'], `(lambda p:f'{{R if p>=${ra} else Y if p>=${wa} else G}}{{p}}%{{X}}')(int((d.get('context_window') or {}).get('used_percentage',0)))`);
+    return f(['ANSI_COLORS'], `(lambda p:f'{R if p>=${ra} else Y if p>=${wa} else G}{p}%{X}')(int((d.get('context_window') or {}).get('used_percentage',0)))`);
   },
   ctxRemainingPct: (opts) => {
     const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
-    return f(['ANSI_COLORS'], `(lambda r,u:(f'{{R if u>=${ra} else Y if u>=${wa} else G}}{{r}}% left{{X}}'))(int((d.get('context_window') or {}).get('remaining_percentage',100)),100-int((d.get('context_window') or {}).get('remaining_percentage',100)))`);
+    return f(['ANSI_COLORS'], `(lambda r,u:f'{R if u>=${ra} else Y if u>=${wa} else G}{r}% left{X}')(int((d.get('context_window') or {}).get('remaining_percentage',100)),100-int((d.get('context_window') or {}).get('remaining_percentage',100)))`);
   },
   ctxTotalTokens: () => f([], "f\"{(d.get('context_window') or {}).get('total_input_tokens',0)+(d.get('context_window') or {}).get('total_output_tokens',0)}tok\""),
   ctxWindowSize: () => f([], "f\"{(d.get('context_window') or {}).get('context_window_size',0)//1000}k ctx\""),
@@ -90,7 +90,7 @@ export const RPY: Record<string, RenderFn> = {
   // rate limits
   rate5hPct: (opts) => {
     const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
-    return f(['ANSI_COLORS'], `(lambda p:f'{{R if p>=${ra} else Y if p>=${wa} else G}}5h:{{p}}%{{X}}')(int((d.get('rate_limits') or {}).get('five_hour',{}).get('used_percentage',0)))`);
+    return f(['ANSI_COLORS'], `(lambda p:f'{R if p>=${ra} else Y if p>=${wa} else G}5h:{p}%{X}')(int((d.get('rate_limits') or {}).get('five_hour',{}).get('used_percentage',0)))`);
   },
   rate5hBar: (opts) => {
     const w = opts.sub.bar?.width ?? 10;
@@ -103,7 +103,7 @@ export const RPY: Record<string, RenderFn> = {
   },
   rate7dPct: (opts) => {
     const [wa, ra] = opts.sub.colorize?.thresholds ?? [75, 90];
-    return f(['ANSI_COLORS'], `(lambda p:f'{{R if p>=${ra} else Y if p>=${wa} else G}}7d:{{p}}%{{X}}')(int((d.get('rate_limits') or {}).get('seven_day',{}).get('used_percentage',0)))`);
+    return f(['ANSI_COLORS'], `(lambda p:f'{R if p>=${ra} else Y if p>=${wa} else G}7d:{p}%{X}')(int((d.get('rate_limits') or {}).get('seven_day',{}).get('used_percentage',0)))`);
   },
   rate7dBar: (opts) => {
     const w = opts.sub.bar?.width ?? 10;

--- a/src/codegen/renderSh.ts
+++ b/src/codegen/renderSh.ts
@@ -109,7 +109,7 @@ export const RSH: Record<string, RenderFn> = {
   ctxCacheCreation: () => f([], '"${CTX_CW}cw"', 'CTX_CW=$(echo "$input"|jq -r \'.context_window.current_usage.cache_creation_input_tokens//0\')'),
   exceeds200k: () => f([], '"$(echo "$input"|jq -r \'if .exceeds_200k_tokens then "!200k" else "" end\')"'),
 
-  costTotalUsd: () => f([], '"$$(echo "$input"|jq -r \'.cost.total_cost_usd//0|.*10000|round/10000\')"'),
+  costTotalUsd: () => f([], '"\\$$(echo "$input"|jq -r \'.cost.total_cost_usd//0|.*10000|round/10000\')"'),
   costDuration: () => f(['__duration'], '"$(__duration "$(echo "$input"|jq -r \'.cost.total_duration_ms//0\')")"'),
   costApiDuration: () => f(['__duration'], '"$(__duration "$(echo "$input"|jq -r \'.cost.total_api_duration_ms//0\')")"'),
   costLines: () => f([], '"+$(echo "$input"|jq -r \'.cost.total_lines_added//0\') -$(echo "$input"|jq -r \'.cost.total_lines_removed//0\')"'),

--- a/src/output/OutputPanel.tsx
+++ b/src/output/OutputPanel.tsx
@@ -32,16 +32,37 @@ export default function OutputPanel() {
 
   const script = useMemo(() => {
     if (selected.length === 0) return '';
-    if (format === 'js') return emitJs(selected, opts);
-    if (format === 'py') return emitPython(selected, opts);
-    if (format === 'ps') return emitPowershell(selected, opts);
-    return emitBash(selected, opts);
+    try {
+      if (format === 'js') return emitJs(selected, opts);
+      if (format === 'py') return emitPython(selected, opts);
+      if (format === 'ps') return emitPowershell(selected, opts);
+      return emitBash(selected, opts);
+    } catch (e) {
+      return `# Error generating script: ${e}`;
+    }
   }, [selected, opts, format]);
 
-  const settings = useMemo(() => emitSettings({ os, format, selected }, opts), [os, format, selected, opts]);
+  const settings = useMemo(() => {
+    try {
+      return emitSettings({ os, format, selected }, opts);
+    } catch (e) {
+      return `# Error: ${e}`;
+    }
+  }, [os, format, selected, opts]);
+
   const preview = useMemo(() => runPreview(selected, opts), [selected, opts]);
   // ansiToHtml escapes all raw text through escapeHtml before injecting HTML
   const previewHtml = useMemo(() => ansiToHtml(preview), [preview]);
+
+  const handleSetFormat = useCallback((f: typeof format) => {
+    setFormat(f);
+    if (f === 'ps') setOs('win');
+  }, [setFormat, setOs]);
+
+  const handleSetOs = useCallback((o: typeof os) => {
+    setOs(o);
+    if (o !== 'win' && format === 'ps') setFormat('sh');
+  }, [setOs, setFormat, format]);
 
   const copy = useCallback((text: string) => {
     navigator.clipboard.writeText(text).then(() => {
@@ -68,14 +89,22 @@ export default function OutputPanel() {
         <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
           <Typography variant="subtitle1">Output</Typography>
           <Stack direction="row" spacing={1}>
-            <ToggleButtonGroup size="small" exclusive value={os} onChange={(_, v) => v && setOs(v)}>
-              {(['mac','linux','win'] as const).map((o) => (
-                <ToggleButton key={o} value={o}>{o}</ToggleButton>
+            <ToggleButtonGroup size="small" exclusive value={os} onChange={(_, v) => v && handleSetOs(v)}>
+              {(['mac', 'linux', 'win'] as const).map((o) => (
+                <ToggleButton key={o} value={o} disabled={format === 'ps' && o !== 'win'}>
+                  {o}
+                </ToggleButton>
               ))}
             </ToggleButtonGroup>
-            <ToggleButtonGroup size="small" exclusive value={format} onChange={(_, v) => v && setFormat(v)}>
-              {(['sh','py','js','ps'] as const).map((f) => (
-                <ToggleButton key={f} value={f}>{LANG_LABEL[f]}</ToggleButton>
+            <ToggleButtonGroup size="small" exclusive value={format} onChange={(_, v) => v && handleSetFormat(v)}>
+              {(['sh', 'py', 'js', 'ps'] as const).map((f) => (
+                <Tooltip key={f} title={f === 'ps' && os !== 'win' ? 'PowerShell requires Windows' : ''}>
+                  <span>
+                    <ToggleButton value={f} disabled={f === 'ps' && os !== 'win'}>
+                      {LANG_LABEL[f]}
+                    </ToggleButton>
+                  </span>
+                </Tooltip>
               ))}
             </ToggleButtonGroup>
           </Stack>
@@ -83,7 +112,8 @@ export default function OutputPanel() {
 
         {/* Live preview - ansiToHtml escapes all raw text, safe from XSS */}
         <Box sx={{
-          fontFamily: 'monospace', fontSize: 13, p: 1.5, mb: 2,
+          fontFamily: '"Consolas", "Courier New", monospace, "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji"',
+          fontSize: 13, p: 1.5, mb: 2,
           bgcolor: '#0d1117', borderRadius: 1, minHeight: 36,
           whiteSpace: 'pre', overflowX: 'auto',
         }}

--- a/src/output/OutputPanel.tsx
+++ b/src/output/OutputPanel.tsx
@@ -84,7 +84,7 @@ export default function OutputPanel() {
 
   // previewHtml is produced by ansiToHtml which escapes all text via escapeHtml - safe to render
   return (
-    <Card>
+    <Card sx={{ minWidth: 0, overflow: 'hidden' }}>
       <CardContent>
         <Stack direction="row" sx={{ alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
           <Typography variant="subtitle1">Output</Typography>
@@ -142,7 +142,11 @@ export default function OutputPanel() {
           <SyntaxHighlighter
             language={langTag}
             style={vscDarkPlus}
-            customStyle={{ margin: 0, borderRadius: 8, fontSize: 12, maxHeight: '60vh' }}
+            customStyle={{
+              margin: 0, borderRadius: 8, fontSize: 12, maxHeight: '60vh',
+              overflowX: 'auto',
+              fontFamily: '"Consolas", "Courier New", monospace, "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji"',
+            }}
           >
             {current || '# Select parameters on the left…'}
           </SyntaxHighlighter>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,5 +21,6 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "types": ["node", "vite/client"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

- **PowerShell white screen crash**: `emitSettings` threw on `os=mac, format=ps`. Now returns a safe fallback. UI disables the PowerShell button when Windows isn't selected; switching to PowerShell auto-sets OS to Windows; switching OS away from Windows while PowerShell is active auto-reverts to Bash.
- **Python emitter broken**: helper function definitions were inserted mid-function at column 0, causing an `IndentationError` (Python would see `except Exception:` with no matching `try`). Fixed: helpers now go at module level before `def main()`.
- **Python f-strings wrong**: all color expressions used `{{expr}}` (literal braces in f-strings) instead of `{expr}` (evaluated expressions), so output was the raw source text like `{R if p>=90 else Y ...}` instead of an ANSI color string.
- **Long generated lines**: `__pack([expr1, expr2, ...all params...], ...)` was all on one line. Now formats the array vertically in both JS and Python output.
- **PowerShell emitter**: `Strip-Ansi` lookup key was wrong (should be `__stripAnsi`), leaving `__Pack` calling an undefined function at runtime.
- **Bash cost_total_usd**: `$$` expands to PID in bash — fixed to `\$$` (literal `$` + command substitution).
- **Layout**: 40/60 grid split; `SelectedOrder` moved to right column above the output panel.
- **Emoji in preview**: preview box now lists emoji-capable font fallbacks (`Apple Color Emoji`, `Segoe UI Emoji`, `Noto Color Emoji`).
- **CI integration tests** (`emit.integration.test.ts`): generates JS and Python scripts, pipes `SAMPLE_STDIN` via `child_process.spawnSync`, asserts field values appear in output. Bash tests run on Unix+jq, skipped on Windows.

## Test plan

- [ ] 40/42 tests pass (2 Bash skipped — no `jq` on Windows CI)
- [ ] `npm run typecheck` — clean
- [ ] `npm run build` — successful
- [ ] `npm run dev` — select params, switch OS/format; PowerShell only lights up on Windows; preview shows emoji; generated code is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)