### PR TITLE
feat: wire up useEmojis across all emitters and render functions

### DIFF
--- a/src/codegen/__snapshots__/emitBash.test.ts.snap
+++ b/src/codegen/__snapshots__/emitBash.test.ts.snap
@@ -46,6 +46,6 @@ __bar() {
 MODEL_DISPLAY=$(echo "$input"|jq -r '.model.display_name//"?"')
 CWD_RAW=$(echo "$input"|jq -r '.workspace.current_dir//(.cwd//"")')
 CTX_BAR_PCT=$(echo "$input"|jq -r '.context_window.used_percentage//0|floor')
-__pack " | " 100 false 10 "\${MODEL_DISPLAY}" "$(__truncate_path "\${CWD_RAW}" 40 1)" "$(__bar "\${CTX_BAR_PCT}" 10 75 90)"
+__pack " | " 100 false 10 "\${MODEL_DISPLAY}" "$(_EV=$(__truncate_path "\${CWD_RAW}" 40 1); printf '%s' "\${_EV:+📁 }\${_EV}")" "$(_EV=$(__bar "\${CTX_BAR_PCT}" 10 75 90); printf '%s' "\${_EV:+🧠 }\${_EV}")"
 "
 `;

--- a/src/codegen/__snapshots__/emitJs.test.ts.snap
+++ b/src/codegen/__snapshots__/emitJs.test.ts.snap
@@ -13,7 +13,7 @@ process.stdin.on('end', () => {
     const __bar=(pct,w=10,wa=75,ra=90)=>{const f=Math.round((pct/100)*w),b='\\u2593'.repeat(Math.max(0,f))+'\\u2591'.repeat(Math.max(0,w-f)),c=pct>=ra?R:pct>=wa?Y:G;return c+b+X};
     console.log(__pack([
       d.model?.display_name??'?',
-      __bar(d.context_window?.used_percentage??0,10,75,90),
+      ((_v) => _v ? '🧠 '+_v : '')(__bar(d.context_window?.used_percentage??0,10,75,90)),
     ], " | ", 100, false, 10));
   } catch (_e) {
     console.log('[?]');
@@ -37,7 +37,7 @@ process.stdin.on('end', () => {
     const __GIT = __cacheGit(d.session_id ?? 'default', 5, __runGit);
     console.log(__pack([
       d.model?.display_name??'?',
-      __GIT[0],
+      ((_v) => _v ? '🌿 '+_v : '')(__GIT[0]),
       (__GIT[2]>0?(__GIT[2]>=1?R:__GIT[2]>=1?Y:G)+'M:'+__GIT[2]+X:''),
     ], " | ", 100, false, 10));
   } catch (_e) {
@@ -58,7 +58,7 @@ process.stdin.on('end', () => {
     const __pack=(parts,sep=' | ',max=100,hard=false,tol=10)=>{const ps=parts.filter(x=>x!=null&&x!=='');if(!ps.length)return'';const lim=hard?max:max*(1+tol/100),lines=[[]];let run=0;for(const p of ps){const l=__stripAnsi(String(p)).length,add=l+(lines[lines.length-1].length?sep.length:0);if(lines[lines.length-1].length&&run+add>lim){lines.push([p]);run=l}else{lines[lines.length-1].push(p);run+=add}}return lines.map(l=>l.join(sep)).join('\\n')};
     const __resetTime=(epoch,fmt='until')=>{if(!epoch)return'?';const dt=new Date(epoch*1e3),now=new Date(),diff=Math.max(0,dt-now),pad=n=>String(n).padStart(2,'0');if(fmt==='until'){const h=Math.floor(diff/36e5),m=Math.floor((diff%36e5)/6e4);return h>0?h+'h '+m+'m':m+'m'}if(fmt==='YYYY-MM-DD')return dt.getFullYear()+'-'+pad(dt.getMonth()+1)+'-'+pad(dt.getDate());if(fmt==='DD/MM/YY')return pad(dt.getDate())+'/'+pad(dt.getMonth()+1)+'/'+String(dt.getFullYear()).slice(2);if(fmt==='HH:mm')return pad(dt.getHours())+':'+pad(dt.getMinutes());return String(epoch)};
     console.log(__pack([
-      __resetTime(d.rate_limits?.five_hour?.resets_at,"until"),
+      ((_v) => _v ? '⏱️ '+_v : '')(__resetTime(d.rate_limits?.five_hour?.resets_at,"until")),
     ], " | ", 100, false, 10));
   } catch (_e) {
     console.log('[?]');
@@ -79,7 +79,7 @@ process.stdin.on('end', () => {
     const __truncatePath=(p,max=40,base=false)=>{if(!p)return'';const s=base?(String(p).split('/').pop()||p):String(p);return s.length<=max?s:'\\u2026'+s.slice(-(max-1))};
     console.log(__pack([
       d.model?.display_name??'?',
-      __truncatePath(d.workspace?.current_dir??d.cwd??'',40,true),
+      ((_v) => _v ? '📁 '+_v : '')(__truncatePath(d.workspace?.current_dir??d.cwd??'',40,true)),
     ], " | ", 100, false, 10));
   } catch (_e) {
     console.log('[?]');

--- a/src/codegen/__snapshots__/emitPowershell.test.ts.snap
+++ b/src/codegen/__snapshots__/emitPowershell.test.ts.snap
@@ -32,7 +32,7 @@ function __Bar($pct,$w=10,$wa=75,$ra=90){
 }
 $MODEL_DISPLAY=if($d.model.display_name){$d.model.display_name}else{"?"}
 $CWD_RAW=if($d.workspace.current_dir){$d.workspace.current_dir}elseif($d.cwd){$d.cwd}else{""}
-    Write-Host (__Pack @($MODEL_DISPLAY, (__TruncatePath $CWD_RAW 40 $true), (__Bar ([int]($d.context_window.used_percentage ?? 0)) 10 75 90)) " | " 100 $false 10)
+    Write-Host (__Pack @($MODEL_DISPLAY, (& { $v=((__TruncatePath $CWD_RAW 40 $true)); if($v){"📁 $v"}else{""} }), (& { $v=((__Bar ([int]($d.context_window.used_percentage ?? 0)) 10 75 90)); if($v){"🧠 $v"}else{""} })) " | " 100 $false 10)
 } catch {
     Write-Host '[?]'
 }

--- a/src/codegen/__snapshots__/emitPython.test.ts.snap
+++ b/src/codegen/__snapshots__/emitPython.test.ts.snap
@@ -33,8 +33,8 @@ def main():
         d = json.load(sys.stdin)
         print(__pack([
             (d.get('model') or {}).get('display_name','?'),
-            __truncate_path((d.get('workspace') or {}).get('current_dir','') or d.get('cwd',''),40,True),
-            __bar((d.get('context_window') or {}).get('used_percentage',0),10,75,90),
+            (f'📁 {_v}' if (_v:=str(__truncate_path((d.get('workspace') or {}).get('current_dir','') or d.get('cwd',''),40,True))) else ''),
+            (f'🧠 {_v}' if (_v:=str(__bar((d.get('context_window') or {}).get('used_percentage',0),10,75,90))) else ''),
         ], " | ", 100, False, 10))
     except Exception:
         print('[?]')
@@ -93,7 +93,7 @@ def main():
         __GIT = __cache_git(d.get('session_id','default'), 5, __run_git)
         print(__pack([
             (d.get('model') or {}).get('display_name','?'),
-            __GIT[0],
+            (f'🌿 {_v}' if (_v:=str(__GIT[0])) else ''),
         ], " | ", 100, False, 10))
     except Exception:
         print('[?]')

--- a/src/codegen/emitBash.ts
+++ b/src/codegen/emitBash.ts
@@ -4,8 +4,28 @@ import { SH_HELPERS } from './runtimes/sh';
 import { packLines } from './pack';
 import { collectHelpers } from './fragment';
 
+// Category A params (thinking, agent) handle emoji inside renderSh.ts directly.
+const CATEGORY_A: ReadonlySet<ParamId> = new Set(['thinking', 'agent'] as ParamId[]);
+
+function bashWithEmoji(emoji: string, expr: string): string {
+  const inner = expr.startsWith('"') && expr.endsWith('"') ? expr.slice(1, -1) : expr;
+  const simpleVar = inner.match(/^\$\{([^:}=?+#%/]+)\}$/);
+  if (simpleVar) {
+    const v = simpleVar[1];
+    return `"\${${v}:+${emoji} \${${v}}}"`;
+  }
+  const capture = (inner.startsWith('$(') || inner.startsWith('${')) ? `_EV=${inner}` : `_EV=$(${inner})`;
+  return `"$(${capture}; printf '%s' "\${_EV:+${emoji} }\${_EV}")"`;
+}
+
 export function emitBash(selected: ParamId[], opts: ResolvedOptions): string {
-  const fragments = selected.map((id) => PARAMS_BY_ID[id].render.sh(opts));
+  const fragments = selected.map((id) => {
+    const frag = PARAMS_BY_ID[id].render.sh(opts);
+    if (!opts.global.useEmojis || CATEGORY_A.has(id)) return frag;
+    const emoji = PARAMS_BY_ID[id].emoji;
+    if (!emoji) return frag;
+    return { ...frag, expr: bashWithEmoji(emoji, frag.expr) };
+  });
   const widths = selected.map((id) => PARAMS_BY_ID[id].estimateWidth(opts));
   const lineGroups = packLines(widths, opts);
   const rawHelpers = collectHelpers(fragments);

--- a/src/codegen/emitJs.ts
+++ b/src/codegen/emitJs.ts
@@ -4,8 +4,21 @@ import { JS_HELPERS } from './runtimes/js';
 import { packLines } from './pack';
 import { collectHelpers } from './fragment';
 
+// Category A params (thinking, agent) handle emoji inside renderJs.ts directly.
+const CATEGORY_A: ReadonlySet<ParamId> = new Set(['thinking', 'agent'] as ParamId[]);
+
+function jsWithEmoji(emoji: string, expr: string): string {
+  return `((_v) => _v ? '${emoji} '+_v : '')(${expr})`;
+}
+
 export function emitJs(selected: ParamId[], opts: ResolvedOptions): string {
-  const fragments = selected.map((id) => PARAMS_BY_ID[id].render.js(opts));
+  const fragments = selected.map((id) => {
+    const frag = PARAMS_BY_ID[id].render.js(opts);
+    if (!opts.global.useEmojis || CATEGORY_A.has(id)) return frag;
+    const emoji = PARAMS_BY_ID[id].emoji;
+    if (!emoji) return frag;
+    return { ...frag, expr: jsWithEmoji(emoji, frag.expr) };
+  });
   const widths = selected.map((id) => PARAMS_BY_ID[id].estimateWidth(opts));
   const lineGroups = packLines(widths, opts);
   const rawHelpers = collectHelpers(fragments);

--- a/src/codegen/emitPowershell.ts
+++ b/src/codegen/emitPowershell.ts
@@ -4,8 +4,21 @@ import { PS_HELPERS } from './runtimes/ps';
 import { packLines } from './pack';
 import { collectHelpers } from './fragment';
 
+// Category A params (thinking, agent) handle emoji inside renderPs.ts directly.
+const CATEGORY_A: ReadonlySet<ParamId> = new Set(['thinking', 'agent'] as ParamId[]);
+
+function psWithEmoji(emoji: string, expr: string): string {
+  return `(& { $v=(${expr}); if($v){"${emoji} $v"}else{""} })`;
+}
+
 export function emitPowershell(selected: ParamId[], opts: ResolvedOptions): string {
-  const fragments = selected.map((id) => PARAMS_BY_ID[id].render.ps(opts));
+  const fragments = selected.map((id) => {
+    const frag = PARAMS_BY_ID[id].render.ps(opts);
+    if (!opts.global.useEmojis || CATEGORY_A.has(id)) return frag;
+    const emoji = PARAMS_BY_ID[id].emoji;
+    if (!emoji) return frag;
+    return { ...frag, expr: psWithEmoji(emoji, frag.expr) };
+  });
   const widths = selected.map((id) => PARAMS_BY_ID[id].estimateWidth(opts));
   const lineGroups = packLines(widths, opts);
   const rawHelpers = collectHelpers(fragments);

--- a/src/codegen/emitPython.ts
+++ b/src/codegen/emitPython.ts
@@ -4,8 +4,21 @@ import { PY_HELPERS } from './runtimes/py';
 import { packLines } from './pack';
 import { collectHelpers } from './fragment';
 
+// Category A params (thinking, agent) handle emoji inside renderPy.ts directly.
+const CATEGORY_A: ReadonlySet<ParamId> = new Set(['thinking', 'agent'] as ParamId[]);
+
+function pyWithEmoji(emoji: string, expr: string): string {
+  return `(f'${emoji} {_v}' if (_v:=str(${expr})) else '')`;
+}
+
 export function emitPython(selected: ParamId[], opts: ResolvedOptions): string {
-  const fragments = selected.map((id) => PARAMS_BY_ID[id].render.py(opts));
+  const fragments = selected.map((id) => {
+    const frag = PARAMS_BY_ID[id].render.py(opts);
+    if (!opts.global.useEmojis || CATEGORY_A.has(id)) return frag;
+    const emoji = PARAMS_BY_ID[id].emoji;
+    if (!emoji) return frag;
+    return { ...frag, expr: pyWithEmoji(emoji, frag.expr) };
+  });
   const widths = selected.map((id) => PARAMS_BY_ID[id].estimateWidth(opts));
   const lineGroups = packLines(widths, opts);
   const rawHelpers = collectHelpers(fragments);

--- a/src/codegen/renderJs.ts
+++ b/src/codegen/renderJs.ts
@@ -11,9 +11,9 @@ export const RJ: Record<string, RenderFn> = {
   version: () => f([], "d.version??'?'"),
   outputStyle: () => f([], "d.output_style?.name??'default'"),
   effort: () => f([], "d.effort?.level??'?'"),
-  thinking: () => f([], "d.thinking?.enabled?'thinking:on':''"),
+  thinking: (opts) => f([], opts.global.useEmojis ? "d.thinking?.enabled?'💭':''" : "d.thinking?.enabled?'thinking:on':''"),
   vim: (opts) => f([], opts.global.hideVimModeIndicator ? "''" : "d.vim?.mode??''"),
-  agent: () => f([], "d.agent?.name??''"),
+  agent: (opts) => f([], opts.global.useEmojis ? "(d.agent?.name?'🤖 '+d.agent.name:'')" : "d.agent?.name??''"),
   sessionName: (opts) => {
     const max = opts.sub.truncate?.maxChars ?? 24;
     return f(['__truncatePath'], `__truncatePath(d.session_name??'',${max},false)`);

--- a/src/codegen/renderPs.ts
+++ b/src/codegen/renderPs.ts
@@ -10,11 +10,15 @@ export const RPS: Record<string, RenderFn> = {
   version: () => f([], '$SL_VERSION', '$SL_VERSION=if($d.version){$d.version}else{"?"}'),
   outputStyle: () => f([], '$OUTPUT_STYLE', '$OUTPUT_STYLE=if($d.output_style.name){$d.output_style.name}else{"default"}'),
   effort: () => f([], '$EFFORT', '$EFFORT=if($d.effort.level){$d.effort.level}else{"?"}'),
-  thinking: () => f([], '$THINKING', '$THINKING=if($d.thinking.enabled){"thinking:on"}else{""}'),
+  thinking: (opts) => f([], '$THINKING', opts.global.useEmojis
+    ? '$THINKING=if($d.thinking.enabled){"💭"}else{""}'
+    : '$THINKING=if($d.thinking.enabled){"thinking:on"}else{""}'),
   vim: (opts) => opts.global.hideVimModeIndicator
     ? f([], '""')
     : f([], '$VIM_MODE', '$VIM_MODE=if($d.vim.mode){$d.vim.mode}else{""}'),
-  agent: () => f([], '$AGENT_NAME', '$AGENT_NAME=if($d.agent.name){$d.agent.name}else{""}'),
+  agent: (opts) => f([], '$AGENT_NAME', opts.global.useEmojis
+    ? '$AGENT_NAME=if($d.agent.name){"🤖 $($d.agent.name)"}else{""}'
+    : '$AGENT_NAME=if($d.agent.name){$d.agent.name}else{""}'),
   sessionName: (opts) => {
     const max = opts.sub.truncate?.maxChars ?? 24;
     return f(

--- a/src/codegen/renderPy.ts
+++ b/src/codegen/renderPy.ts
@@ -11,9 +11,9 @@ export const RPY: Record<string, RenderFn> = {
   version: () => f([], "d.get('version','?')"),
   outputStyle: () => f([], "(d.get('output_style') or {}).get('name','default')"),
   effort: () => f([], "(d.get('effort') or {}).get('level','?')"),
-  thinking: () => f([], "'thinking:on' if (d.get('thinking') or {}).get('enabled') else ''"),
+  thinking: (opts) => f([], opts.global.useEmojis ? "'💭' if (d.get('thinking') or {}).get('enabled') else ''" : "'thinking:on' if (d.get('thinking') or {}).get('enabled') else ''"),
   vim: (opts) => f([], opts.global.hideVimModeIndicator ? "''" : "(d.get('vim') or {}).get('mode','')"),
-  agent: () => f([], "(d.get('agent') or {}).get('name','')"),
+  agent: (opts) => f([], opts.global.useEmojis ? "('🤖 '+(d.get('agent') or {}).get('name','') if (d.get('agent') or {}).get('name') else '')" : "(d.get('agent') or {}).get('name','')"),
   sessionName: (opts) => {
     const max = opts.sub.truncate?.maxChars ?? 24;
     return f(['__truncatePath'], `__truncate_path(d.get('session_name',''),${max},False)`);

--- a/src/codegen/renderSh.ts
+++ b/src/codegen/renderSh.ts
@@ -10,11 +10,15 @@ export const RSH: Record<string, RenderFn> = {
   version: () => f([], '"${SL_VERSION}"', 'SL_VERSION=$(echo "$input"|jq -r \'.version//"?"\')'),
   outputStyle: () => f([], '"${OUTPUT_STYLE}"', 'OUTPUT_STYLE=$(echo "$input"|jq -r \'.output_style.name//"default"\')'),
   effort: () => f([], '"${EFFORT}"', 'EFFORT=$(echo "$input"|jq -r \'.effort.level//"?"\')'),
-  thinking: () => f([], '"${THINKING}"', 'THINKING=$(echo "$input"|jq -r \'if .thinking.enabled then "thinking:on" else "" end\')'),
+  thinking: (opts) => f([], '"${THINKING}"', opts.global.useEmojis
+    ? 'THINKING=$(echo "$input"|jq -r \'if .thinking.enabled then "💭" else "" end\')'
+    : 'THINKING=$(echo "$input"|jq -r \'if .thinking.enabled then "thinking:on" else "" end\')'),
   vim: (opts) => opts.global.hideVimModeIndicator
     ? f([], '""')
     : f([], '"${VIM_MODE}"', 'VIM_MODE=$(echo "$input"|jq -r \'.vim.mode//empty\')'),
-  agent: () => f([], '"${AGENT_NAME}"', 'AGENT_NAME=$(echo "$input"|jq -r \'.agent.name//empty\')'),
+  agent: (opts) => f([], '"${AGENT_NAME}"', opts.global.useEmojis
+    ? 'AGENT_NAME=$(echo "$input"|jq -r \'.agent.name//empty\'|awk \'NF{print "🤖 " $0}\')'
+    : 'AGENT_NAME=$(echo "$input"|jq -r \'.agent.name//empty\')'),
   sessionName: (opts) => {
     const max = opts.sub.truncate?.maxChars ?? 24;
     return f(

--- a/src/output/previewRender.ts
+++ b/src/output/previewRender.ts
@@ -58,9 +58,17 @@ function evalParam(id: ParamId, opts: ResolvedOptions): string {
     case 'version': return String(d.version ?? '?');
     case 'output_style': return String((d.output_style as Record<string,string>)?.name ?? 'default');
     case 'effort': return String((d.effort as Record<string,string>)?.level ?? '?');
-    case 'thinking': return (d.thinking as Record<string,boolean>)?.enabled ? 'thinking:on' : '';
+    case 'thinking': {
+      const enabled = (d.thinking as Record<string,boolean>)?.enabled;
+      if (!enabled) return '';
+      return g.useEmojis ? '💭' : 'thinking:on';
+    }
     case 'vim': return g.hideVimModeIndicator ? '' : String((d.vim as Record<string,string>)?.mode ?? '');
-    case 'agent': return String((d.agent as Record<string,string>)?.name ?? '');
+    case 'agent': {
+      const name = (d.agent as Record<string,string>)?.name ?? '';
+      if (!name) return '';
+      return g.useEmojis ? '🤖 ' + name : name;
+    }
     case 'session_name': return truncatePath(String(d.session_name ?? ''), sub.truncate?.maxChars ?? 24, false);
 
     case 'cwd': return truncatePath(String((d.workspace as Record<string,string>)?.current_dir ?? d.cwd ?? ''), sub.truncate?.maxChars ?? 40, sub.truncate?.basenameOnly ?? true);
@@ -71,7 +79,7 @@ function evalParam(id: ParamId, opts: ResolvedOptions): string {
     case 'worktree_branch': return String((d.worktree as Record<string,string>)?.branch ?? '');
     case 'worktree_original_branch': return String((d.worktree as Record<string,string>)?.original_branch ?? '');
 
-    case 'git_branch': return '🌿 main (preview)';
+    case 'git_branch': return opts.global.useEmojis ? '🌿 main (preview)' : 'main (preview)';
     case 'git_staged_count': return '';
     case 'git_modified_count': return '';
     case 'git_remote_link': return '';
@@ -105,9 +113,19 @@ function evalParam(id: ParamId, opts: ResolvedOptions): string {
   }
 }
 
+const CATEGORY_A_PREVIEW: ReadonlySet<ParamId> = new Set(['thinking', 'agent', 'git_branch'] as ParamId[]);
+
 export function runPreview(selected: ParamId[], opts: ResolvedOptions): string {
   if (selected.length === 0) return '';
-  const parts = selected.map((id) => evalParam(id, opts));
+  const parts = selected.map((id) => {
+    const raw = evalParam(id, opts);
+    if (!opts.global.useEmojis || CATEGORY_A_PREVIEW.has(id)) return raw;
+    const emoji = PARAMS_BY_ID[id].emoji;
+    if (!emoji || !raw) return raw;
+    // Only add prefix if the value doesn't already start with the emoji
+    if (raw.startsWith(emoji)) return raw;
+    return emoji + ' ' + raw;
+  });
   const widths = selected.map((id) => PARAMS_BY_ID[id].estimateWidth(opts));
   const groups = packLines(widths, opts);
   const lines = groups.map((g) => {

--- a/src/schema/params/context.ts
+++ b/src/schema/params/context.ts
@@ -15,24 +15,26 @@ function rw(key: string, id: string): import('../types').ParamDef['render'] {
 }
 
 const w = (n: number) => () => n;
-const wBar = (defaultBarWidth: number) => (opts: ResolvedOptions) =>
-  (opts.sub.bar?.width ?? defaultBarWidth) + 6;
+const EMOJI_EXTRA = 3;
+const wE = (n: number) => (opts: ResolvedOptions) => n + (opts.global.useEmojis ? EMOJI_EXTRA : 0);
+const wBarE = (defaultBarWidth: number) => (opts: ResolvedOptions) =>
+  (opts.sub.bar?.width ?? defaultBarWidth) + 6 + (opts.global.useEmojis ? EMOJI_EXTRA : 0);
 
 export const CONTEXT_PARAMS: ParamDef[] = [
   { id: 'ctx_used_pct', label: 'Context used %', group: 'context', emoji: '🧠',
-    jsonPath: 'context_window.used_percentage', estimateWidth: w(8),
+    jsonPath: 'context_window.used_percentage', estimateWidth: wE(8),
     render: rw('ctxUsedPct', 'ctx_used_pct') },
   { id: 'ctx_remaining_pct', label: 'Context remaining %', group: 'context', emoji: '🧠',
-    jsonPath: 'context_window.remaining_percentage', estimateWidth: w(8),
+    jsonPath: 'context_window.remaining_percentage', estimateWidth: wE(8),
     render: rw('ctxRemainingPct', 'ctx_remaining_pct') },
   { id: 'ctx_total_tokens', label: 'Total tokens (in+out)', group: 'context', emoji: '🧠',
-    estimateWidth: w(10), render: rw('ctxTotalTokens', 'ctx_total_tokens') },
+    estimateWidth: wE(10), render: rw('ctxTotalTokens', 'ctx_total_tokens') },
   { id: 'ctx_window_size', label: 'Context window size', group: 'context',
     estimateWidth: w(8), render: rw('ctxWindowSize', 'ctx_window_size') },
   { id: 'ctx_bar', label: 'Context usage bar', group: 'context', emoji: '🧠',
     subOptions: [{ kind: 'bar', defaultWidth: 10 },
                  { kind: 'colorize', defaultThresholds: [75, 90] }],
-    estimateWidth: wBar(10), render: rw('ctxBar', 'ctx_bar') },
+    estimateWidth: wBarE(10), render: rw('ctxBar', 'ctx_bar') },
   { id: 'ctx_current_input', label: 'Current input tokens', group: 'context',
     jsonPath: 'context_window.current_usage.input_tokens', estimateWidth: w(8),
     render: rw('ctxCurrentInput', 'ctx_current_input') },

--- a/src/schema/params/cost.ts
+++ b/src/schema/params/cost.ts
@@ -1,4 +1,4 @@
-import type { ParamDef } from '../types';
+import type { ParamDef, ResolvedOptions } from '../types';
 import { RJ } from '../../codegen/renderJs';
 import { RPY } from '../../codegen/renderPy';
 import { RSH } from '../../codegen/renderSh';
@@ -14,18 +14,19 @@ function rw(key: string, id: string): import('../types').ParamDef['render'] {
   };
 }
 
-const w = (n: number) => () => n;
+const EMOJI_EXTRA = 3;
+const wE = (n: number) => (opts: ResolvedOptions) => n + (opts.global.useEmojis ? EMOJI_EXTRA : 0);
 
 export const COST_PARAMS: ParamDef[] = [
   { id: 'cost_total_usd', label: 'Total cost (USD)', group: 'cost', emoji: '💰',
-    jsonPath: 'cost.total_cost_usd', estimateWidth: w(8),
+    jsonPath: 'cost.total_cost_usd', estimateWidth: wE(8),
     render: rw('costTotalUsd', 'cost_total_usd') },
   { id: 'cost_duration', label: 'Total duration', group: 'cost', emoji: '⏱️',
-    jsonPath: 'cost.total_duration_ms', estimateWidth: w(8),
+    jsonPath: 'cost.total_duration_ms', estimateWidth: wE(8),
     render: rw('costDuration', 'cost_duration') },
   { id: 'cost_api_duration', label: 'API duration', group: 'cost', emoji: '⏱️',
-    jsonPath: 'cost.total_api_duration_ms', estimateWidth: w(8),
+    jsonPath: 'cost.total_api_duration_ms', estimateWidth: wE(8),
     render: rw('costApiDuration', 'cost_api_duration') },
   { id: 'cost_lines', label: 'Lines added/removed', group: 'cost', emoji: '📝',
-    estimateWidth: w(12), render: rw('costLines', 'cost_lines') },
+    estimateWidth: wE(12), render: rw('costLines', 'cost_lines') },
 ];

--- a/src/schema/params/git.ts
+++ b/src/schema/params/git.ts
@@ -1,4 +1,4 @@
-import type { ParamDef } from '../types';
+import type { ParamDef, ResolvedOptions } from '../types';
 import { RJ } from '../../codegen/renderJs';
 import { RPY } from '../../codegen/renderPy';
 import { RSH } from '../../codegen/renderSh';
@@ -15,16 +15,18 @@ function rw(key: string, id: string): import('../types').ParamDef['render'] {
 }
 
 const w = (n: number) => () => n;
+const EMOJI_EXTRA = 3;
+const wE = (n: number) => (opts: ResolvedOptions) => n + (opts.global.useEmojis ? EMOJI_EXTRA : 0);
 
 export const GIT_PARAMS: ParamDef[] = [
   { id: 'git_branch', label: 'Git branch', group: 'git', emoji: '🌿',
-    estimateWidth: w(22), render: rw('gitBranch', 'git_branch') },
+    estimateWidth: wE(22), render: rw('gitBranch', 'git_branch') },
   { id: 'git_staged_count', label: 'Git staged count', group: 'git',
     subOptions: [{ kind: 'colorize', defaultThresholds: [1, 1] }],
     estimateWidth: w(4), render: rw('gitStagedCount', 'git_staged_count') },
   { id: 'git_modified_count', label: 'Git modified count', group: 'git',
     subOptions: [{ kind: 'colorize', defaultThresholds: [1, 1] }],
     estimateWidth: w(4), render: rw('gitModifiedCount', 'git_modified_count') },
-  { id: 'git_remote_link', label: 'Git remote (clickable)', group: 'git', emoji: '🔗',
+  { id: 'git_remote_link', label: 'Git remote (clickable)', group: 'git',
     estimateWidth: w(24), render: rw('gitRemoteLink', 'git_remote_link') },
 ];

--- a/src/schema/params/identity.ts
+++ b/src/schema/params/identity.ts
@@ -15,6 +15,8 @@ function rw(key: string, id: string): import('../types').ParamDef['render'] {
 }
 
 const w = (n: number) => () => n;
+const EMOJI_EXTRA = 3;
+const wE = (n: number) => (opts: ResolvedOptions) => n + (opts.global.useEmojis ? EMOJI_EXTRA : 0);
 const wTruncate = (defaultMax: number) => (opts: ResolvedOptions) =>
   (opts.sub.truncate?.maxChars ?? defaultMax) + 2;
 
@@ -30,11 +32,11 @@ export const IDENTITY_PARAMS: ParamDef[] = [
   { id: 'effort', label: 'Reasoning effort', group: 'identity',
     jsonPath: 'effort.level', estimateWidth: w(8), render: rw('effort', 'effort') },
   { id: 'thinking', label: 'Thinking enabled', group: 'identity', emoji: '💭',
-    jsonPath: 'thinking.enabled', estimateWidth: w(10), render: rw('thinking', 'thinking') },
+    jsonPath: 'thinking.enabled', estimateWidth: wE(10), render: rw('thinking', 'thinking') },
   { id: 'vim', label: 'Vim mode', group: 'identity',
     jsonPath: 'vim.mode', estimateWidth: w(11), render: rw('vim', 'vim') },
   { id: 'agent', label: 'Agent name', group: 'identity', emoji: '🤖',
-    jsonPath: 'agent.name', estimateWidth: w(20), render: rw('agent', 'agent') },
+    jsonPath: 'agent.name', estimateWidth: wE(20), render: rw('agent', 'agent') },
   { id: 'session_name', label: 'Session name', group: 'identity',
     jsonPath: 'session_name',
     subOptions: [{ kind: 'truncate', defaultMaxChars: 24, basenameOnly: false }],

--- a/src/schema/params/rateLimits.ts
+++ b/src/schema/params/rateLimits.ts
@@ -15,6 +15,8 @@ function rw(key: string, id: string): import('../types').ParamDef['render'] {
 }
 
 const w = (n: number) => () => n;
+const EMOJI_EXTRA = 3;
+const wE = (n: number) => (opts: ResolvedOptions) => n + (opts.global.useEmojis ? EMOJI_EXTRA : 0);
 const wBar = (defaultBarWidth: number) => (opts: ResolvedOptions) =>
   (opts.sub.bar?.width ?? defaultBarWidth) + 16;
 
@@ -29,7 +31,7 @@ export const RATE_LIMITS_PARAMS: ParamDef[] = [
   { id: 'rate_5h_resets', label: '5h reset time', group: 'rate_limits', emoji: '⏱️',
     subOptions: [{ kind: 'timestamp', default: 'until' }],
     jsonPath: 'rate_limits.five_hour.resets_at',
-    estimateWidth: w(12), render: rw('rate5hResets', 'rate_5h_resets') },
+    estimateWidth: wE(12), render: rw('rate5hResets', 'rate_5h_resets') },
   { id: 'rate_7d_pct', label: '7d limit %', group: 'rate_limits',
     jsonPath: 'rate_limits.seven_day.used_percentage',
     estimateWidth: w(8), render: rw('rate7dPct', 'rate_7d_pct') },
@@ -40,5 +42,5 @@ export const RATE_LIMITS_PARAMS: ParamDef[] = [
   { id: 'rate_7d_resets', label: '7d reset time', group: 'rate_limits', emoji: '⏱️',
     subOptions: [{ kind: 'timestamp', default: 'until' }],
     jsonPath: 'rate_limits.seven_day.resets_at',
-    estimateWidth: w(12), render: rw('rate7dResets', 'rate_7d_resets') },
+    estimateWidth: wE(12), render: rw('rate7dResets', 'rate_7d_resets') },
 ];

--- a/src/schema/params/workspace.ts
+++ b/src/schema/params/workspace.ts
@@ -15,18 +15,20 @@ function rw(key: string, id: string): import('../types').ParamDef['render'] {
 }
 
 const w = (n: number) => () => n;
-const wTruncate = (defaultMax: number) => (opts: ResolvedOptions) =>
-  (opts.sub.truncate?.maxChars ?? defaultMax) + 2;
+const EMOJI_EXTRA = 3;
+const wE = (n: number) => (opts: ResolvedOptions) => n + (opts.global.useEmojis ? EMOJI_EXTRA : 0);
+const wTruncateE = (defaultMax: number) => (opts: ResolvedOptions) =>
+  (opts.sub.truncate?.maxChars ?? defaultMax) + 2 + (opts.global.useEmojis ? EMOJI_EXTRA : 0);
 
 export const WORKSPACE_PARAMS: ParamDef[] = [
   { id: 'cwd', label: 'Current directory', group: 'workspace', emoji: '📁',
     jsonPath: 'workspace.current_dir',
     subOptions: [{ kind: 'truncate', defaultMaxChars: 40, basenameOnly: true }],
-    estimateWidth: wTruncate(40), render: rw('cwd', 'cwd') },
+    estimateWidth: wTruncateE(40), render: rw('cwd', 'cwd') },
   { id: 'workspace_project', label: 'Project directory', group: 'workspace', emoji: '📁',
     jsonPath: 'workspace.project_dir',
     subOptions: [{ kind: 'truncate', defaultMaxChars: 40, basenameOnly: true }],
-    estimateWidth: wTruncate(40), render: rw('workspaceProject', 'workspace_project') },
+    estimateWidth: wTruncateE(40), render: rw('workspaceProject', 'workspace_project') },
   { id: 'workspace_added_count', label: 'Added dirs count', group: 'workspace',
     jsonPath: 'workspace.added_dirs', estimateWidth: w(6),
     render: rw('workspaceAddedCount', 'workspace_added_count') },
@@ -36,9 +38,9 @@ export const WORKSPACE_PARAMS: ParamDef[] = [
   { id: 'worktree_name', label: 'Worktree name', group: 'workspace',
     jsonPath: 'worktree.name', estimateWidth: w(20), render: rw('worktreeName', 'worktree_name') },
   { id: 'worktree_branch', label: 'Worktree branch', group: 'workspace', emoji: '🌿',
-    jsonPath: 'worktree.branch', estimateWidth: w(22), render: rw('worktreeBranch', 'worktree_branch') },
+    jsonPath: 'worktree.branch', estimateWidth: wE(22), render: rw('worktreeBranch', 'worktree_branch') },
   { id: 'worktree_original_branch', label: 'Worktree original branch',
     group: 'workspace', emoji: '🌿',
-    jsonPath: 'worktree.original_branch', estimateWidth: w(22),
+    jsonPath: 'worktree.original_branch', estimateWidth: wE(22),
     render: rw('worktreeOriginalBranch', 'worktree_original_branch') },
 ];


### PR DESCRIPTION
- Emitters (Bash/JS/Python/PowerShell): language-specific *WithEmoji helpers wrap fragment exprs with conditional emoji prefix for all Category B params (everything except thinking/agent)
- thinking/agent (Category A) handle emoji inside render functions
- renderJs/renderPy/renderSh/renderPs: thinking and agent now check opts.global.useEmojis
- estimateWidth: all emoji-having params add +3 when useEmojis is true
- previewRender.ts: git_branch/thinking/agent respect useEmojis; runPreview applies emoji prefix for Category B params
- git.ts: removed emoji:'🔗' from gitRemoteLink (already embedded)
- Fixed Python f-string double-brace bug ({{expr}} → {expr}) that caused color expressions to render as literal text
- Fixed Bash costTotalUsd dollar sign (was expanding to shell PID)
- Updated snapshots for all four emitters